### PR TITLE
[messagingframework] Sync with upstream. JB#61278

### DIFF
--- a/rpm/0001-fix-tests-installation-path.patch
+++ b/rpm/0001-fix-tests-installation-path.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] fix tests installation path.
  6 files changed, 536 insertions(+), 536 deletions(-)
 
 diff --git a/benchmarks/tst_messageserver/tst_messageserver.pro b/benchmarks/tst_messageserver/tst_messageserver.pro
-index 2d50131a..1dc2ddd5 100644
+index a389e4ae..e4364c28 100644
 --- a/benchmarks/tst_messageserver/tst_messageserver.pro
 +++ b/benchmarks/tst_messageserver/tst_messageserver.pro
 @@ -2,7 +2,7 @@ TEMPLATE = app
@@ -23,8 +23,8 @@ index 2d50131a..1dc2ddd5 100644
 -target.path += $$QMF_INSTALL_ROOT/tests5
 +target.path += /opt/tests/qmf-qt5
  
- BASE=../../
- include($$BASE/common.pri)
+ DEPENDPATH += . 3rdparty
+ 
 diff --git a/tests/qt5/tests.xml b/tests/qt5/tests.xml
 index ffbb593f..ac9464a6 100644
 --- a/tests/qt5/tests.xml
@@ -1462,18 +1462,17 @@ index ffbb593f..ac9464a6 100644
           <environments>
              <scratchbox>true</scratchbox>
 diff --git a/tests/tests.pri b/tests/tests.pri
-index 623b19ca..1d3ba39e 100644
+index 11065508..872fa50b 100644
 --- a/tests/tests.pri
 +++ b/tests/tests.pri
-@@ -3,7 +3,7 @@ QT += testlib
+@@ -3,6 +3,6 @@ QT += testlib
  CONFIG += testcase
  
  QT += qmfclient qmfclient-private
 -target.path += $$QMF_INSTALL_ROOT/tests5
 +target.path += /opt/tests/qmf-qt5
  
- include(../common.pri)
- 
+ INSTALLS += target
 diff --git a/tests/tests.pro b/tests/tests.pro
 index f9127b7f..85499a4f 100644
 --- a/tests/tests.pro

--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -86,33 +86,17 @@ base-qmf-oauth2-plugin/oauth2plugin.cpp
 
 Change-Id: Id90fddd10e205da7b807000e042f4a5b13edd4c0
 ---
- common.pri                                    |    5 +
  .../qmfclient/qmailaccountlistmodel.cpp       |   44 +-
- src/libraries/qmfclient/qmailstore_p.cpp      | 1234 ++++++++++++++++-
+ src/libraries/qmfclient/qmailstore_p.cpp      | 1235 ++++++++++++++++-
  src/libraries/qmfclient/qmailstore_p.h        |   41 +-
  src/libraries/qmfclient/qmfclient.pro         |   18 +
  src/libraries/qmfclient/share/email.provider  |   12 +
  src/libraries/qmfclient/share/email.service   |   65 +
- 7 files changed, 1378 insertions(+), 41 deletions(-)
+ tests/tests.pri                               |    6 +
+ 7 files changed, 1380 insertions(+), 41 deletions(-)
  create mode 100644 src/libraries/qmfclient/share/email.provider
  create mode 100644 src/libraries/qmfclient/share/email.service
 
-diff --git a/common.pri b/common.pri
-index c690ce66..9c17355c 100644
---- a/common.pri
-+++ b/common.pri
-@@ -2,6 +2,11 @@ CONFIG(debug,debug|release) {
-     DEFINES += QMF_ENABLE_LOGGING
- }
- 
-+contains(DEFINES,USE_ACCOUNTS_QT) {
-+    CONFIG += link_pkgconfig
-+    QT += xml
-+    PKGCONFIG += accounts-qt5
-+}
- 
- win32 | macx {
- 
 diff --git a/src/libraries/qmfclient/qmailaccountlistmodel.cpp b/src/libraries/qmfclient/qmailaccountlistmodel.cpp
 index 28f566cb..63d98c53 100644
 --- a/src/libraries/qmfclient/qmailaccountlistmodel.cpp
@@ -175,7 +159,7 @@ index 28f566cb..63d98c53 100644
  }
  
 diff --git a/src/libraries/qmfclient/qmailstore_p.cpp b/src/libraries/qmfclient/qmailstore_p.cpp
-index bd858eba..6785f1f4 100644
+index bd858eba..e6c51a1f 100644
 --- a/src/libraries/qmfclient/qmailstore_p.cpp
 +++ b/src/libraries/qmfclient/qmailstore_p.cpp
 @@ -48,6 +48,10 @@
@@ -1627,7 +1611,7 @@ index bd858eba..6785f1f4 100644
      // Do not report any deleted entities as updated
      for (QMailMessageIdList::iterator mit = updatedMessageIds.begin(); mit != updatedMessageIds.end(); ) {
          if (deletedMessageIds.contains(*mit)) {
-@@ -9821,3 +10908,108 @@ void QMailStorePrivate::reconnectIpc()
+@@ -9821,3 +10908,109 @@ void QMailStorePrivate::reconnectIpc()
          ipcLastDbUpdated = lastDbUpdated;
      }
  }
@@ -1687,7 +1671,7 @@ index bd858eba..6785f1f4 100644
 +    ids << QMailAccountId(id);
 +    Q_Q(QMailStore);
 +
-+    ENFORCE(QMetaObject::invokeMethod(q, "accountsAdded", Qt::QueuedConnection, Q_ARG(QMailAccountIdList, ids)));
++    QMetaObject::invokeMethod(q, "accountsAdded", Qt::QueuedConnection, Q_ARG(QMailAccountIdList, ids));
 +}
 +
 +void QMailStorePrivate::accountRemoved(Accounts::AccountId id)
@@ -1697,7 +1681,7 @@ index bd858eba..6785f1f4 100644
 +        return;
 +
 +    const QMailAccountId& qId = QMailAccountId(id);
-+    ENFORCE(QMetaObject::invokeMethod(this, "onAccountRemovedFinished", Qt::QueuedConnection, Q_ARG(QMailAccountId, qId)));
++    QMetaObject::invokeMethod(this, "onAccountRemovedFinished", Qt::QueuedConnection, Q_ARG(QMailAccountId, qId));
 +}
 +
 +void QMailStorePrivate::onAccountRemovedFinished(const QMailAccountId &id)
@@ -1717,7 +1701,8 @@ index bd858eba..6785f1f4 100644
 +    const QMailAccountId& qId = QMailAccountId(id);
 +    accountCache.remove(qId);
 +    Q_Q(QMailStore);
-+    ENFORCE(QMetaObject::invokeMethod(q, "accountsUpdated", Qt::QueuedConnection, Q_ARG(QMailAccountIdList, QMailAccountIdList() << qId)));
++    QMetaObject::invokeMethod(q, "accountsUpdated", Qt::QueuedConnection,
++                              Q_ARG(QMailAccountIdList, QMailAccountIdList() << qId));
 +}
 +
 +bool QMailStorePrivate::accountValid(Accounts::AccountId id) const
@@ -1830,7 +1815,7 @@ index ae3c25e6..b7898c7c 100644
      class Cache
      {
 diff --git a/src/libraries/qmfclient/qmfclient.pro b/src/libraries/qmfclient/qmfclient.pro
-index 95cd2bd8..ea2f00fb 100644
+index 73f10b76..62e6415d 100644
 --- a/src/libraries/qmfclient/qmfclient.pro
 +++ b/src/libraries/qmfclient/qmfclient.pro
 @@ -2,6 +2,24 @@ TARGET     = QmfClient
@@ -1947,3 +1932,18 @@ index 00000000..9f6ef320
 +     -->
 +  </template>
 +</service>
+diff --git a/tests/tests.pri b/tests/tests.pri
+index 872fa50b..e81f4e07 100644
+--- a/tests/tests.pri
++++ b/tests/tests.pri
+@@ -5,4 +5,10 @@ CONFIG += testcase
+ QT += qmfclient qmfclient-private
+ target.path += /opt/tests/qmf-qt5
+ 
++contains(DEFINES, USE_ACCOUNTS_QT) {
++    CONFIG += link_pkgconfig
++    QT += xml
++    PKGCONFIG += accounts-qt5
++}
++
+ INSTALLS += target

--- a/rpm/0003-SSO-integration.patch
+++ b/rpm/0003-SSO-integration.patch
@@ -78,7 +78,7 @@ Change-Id: If6e92e95a3a5c53ac46fe300906508804f0fd9ce
  src/libraries/qmfclient/ssoauthplugin.h       |  74 ++++
  src/libraries/qmfclient/ssosessionmanager.cpp | 388 ++++++++++++++++++
  src/libraries/qmfclient/ssosessionmanager.h   | 112 +++++
- .../qmfmessageserver/qmailauthenticator.cpp   |  20 +-
+ .../qmfmessageserver/qmailauthenticator.cpp   |  19 +-
  .../qmfmessageserver/qmailauthenticator.h     |   4 +
  .../qmfmessageserver/qmfmessageserver.pro     |   9 +
  src/libraries/qmfwidgets/qmfwidgets.pro       |   6 +
@@ -93,13 +93,13 @@ Change-Id: If6e92e95a3a5c53ac46fe300906508804f0fd9ce
  src/plugins/messageservices/pop/pop.pro       |   7 +
  .../messageservices/pop/popauthenticator.cpp  |  33 +-
  .../messageservices/pop/popauthenticator.h    |   4 +
- src/plugins/messageservices/pop/popclient.cpp | 122 ++++++
+ src/plugins/messageservices/pop/popclient.cpp | 123 ++++++
  src/plugins/messageservices/pop/popclient.h   |  25 ++
  .../messageservices/pop/popservice.cpp        |  25 ++
  src/plugins/messageservices/smtp/smtp.pro     |   7 +
- .../smtp/smtpauthenticator.cpp                | 121 +++++-
+ .../smtp/smtpauthenticator.cpp                | 118 +++++-
  .../messageservices/smtp/smtpauthenticator.h  |   5 +
- .../messageservices/smtp/smtpclient.cpp       | 167 +++++++-
+ .../messageservices/smtp/smtpclient.cpp       | 168 +++++++-
  src/plugins/messageservices/smtp/smtpclient.h |  28 ++
  .../messageservices/smtp/smtpservice.cpp      |   8 +
  src/plugins/plugins.pro                       |   3 +
@@ -109,7 +109,7 @@ Change-Id: If6e92e95a3a5c53ac46fe300906508804f0fd9ce
  src/tools/messageserver/servicehandler.cpp    |  13 +
  tests/tst_qmailstore/tst_qmailstore.cpp       |  93 ++++-
  tests/tst_smtp/tst_smtp.pro                   |   4 +
- 38 files changed, 2412 insertions(+), 39 deletions(-)
+ 38 files changed, 2414 insertions(+), 35 deletions(-)
  create mode 100644 src/libraries/qmfclient/ssoaccountmanager.cpp
  create mode 100644 src/libraries/qmfclient/ssoaccountmanager.h
  create mode 100644 src/libraries/qmfclient/ssoauthplugin.cpp
@@ -121,7 +121,7 @@ Change-Id: If6e92e95a3a5c53ac46fe300906508804f0fd9ce
  create mode 100644 src/plugins/ssoauth/password/passwordplugin.h
 
 diff --git a/src/libraries/qmfclient/qmfclient.pro b/src/libraries/qmfclient/qmfclient.pro
-index ea2f00fb..6fedb7bd 100644
+index 62e6415d..da650b33 100644
 --- a/src/libraries/qmfclient/qmfclient.pro
 +++ b/src/libraries/qmfclient/qmfclient.pro
 @@ -8,6 +8,17 @@ CONFIG    += warn_on
@@ -501,7 +501,7 @@ index 00000000..bbc59a76
 +#endif // SSOAUTHPLUGIN_H
 diff --git a/src/libraries/qmfclient/ssosessionmanager.cpp b/src/libraries/qmfclient/ssosessionmanager.cpp
 new file mode 100644
-index 00000000..d5232a9e
+index 00000000..f520e607
 --- /dev/null
 +++ b/src/libraries/qmfclient/ssosessionmanager.cpp
 @@ -0,0 +1,388 @@
@@ -696,10 +696,10 @@ index 00000000..d5232a9e
 +                            << " using authentication method " << _authMethod;
 +       _session = _identity->createSession(_authMethod);
 +        Q_ASSERT (_session);
-+        ENFORCE(connect(_session, SIGNAL(response(SignOn::SessionData)),
-+                        this, SLOT(ssoResponse(SignOn::SessionData))));
-+        ENFORCE(connect(_session, SIGNAL(error(SignOn::Error)),
-+                        this, SLOT(ssoSessionError(SignOn::Error))));
++        connect(_session, SIGNAL(response(SignOn::SessionData)),
++                this, SLOT(ssoResponse(SignOn::SessionData)));
++        connect(_session, SIGNAL(error(SignOn::Error)),
++                this, SLOT(ssoSessionError(SignOn::Error)));
 +        _waitForSso = true;
 +        _authService = SSOAuthFactory::createService(_authMethod);
 +        _sessionData = _authService->sessionData(_accountProvider, _authParameters);
@@ -1012,18 +1012,10 @@ index 00000000..61806ba4
 +
 +#endif // SSOSESSIONMANAGER_H
 diff --git a/src/libraries/qmfmessageserver/qmailauthenticator.cpp b/src/libraries/qmfmessageserver/qmailauthenticator.cpp
-index 81983691..212dc33f 100644
+index 81983691..01f65d69 100644
 --- a/src/libraries/qmfmessageserver/qmailauthenticator.cpp
 +++ b/src/libraries/qmfmessageserver/qmailauthenticator.cpp
-@@ -32,7 +32,6 @@
- ****************************************************************************/
- 
- #include "qmailauthenticator.h"
--#include "qmailnamespace.h"
- #include <qmailserviceconfiguration.h>
- #include <qcryptographichash.h>
- #include <qbytearray.h>
-@@ -148,6 +147,23 @@ QByteArray QMailAuthenticator::getAuthentication(const QMailAccountConfiguration
+@@ -148,6 +148,23 @@ QByteArray QMailAuthenticator::getAuthentication(const QMailAccountConfiguration
      should be decoded before invocation, and the result should be encoded for
      transmission.
  */
@@ -1047,7 +1039,7 @@ index 81983691..212dc33f 100644
  QByteArray QMailAuthenticator::getResponse(const QMailAccountConfiguration::ServiceConfiguration &svcCfg, const QByteArray &challenge)
  {
      QMailServiceConfiguration configuration(svcCfg);
-@@ -165,4 +181,4 @@ QByteArray QMailAuthenticator::getResponse(const QMailAccountConfiguration::Serv
+@@ -165,4 +182,4 @@ QByteArray QMailAuthenticator::getResponse(const QMailAccountConfiguration::Serv
      // Unknown service type and/or authentication type
      return QByteArray();
  }
@@ -1101,12 +1093,12 @@ index ddff356e..dafd090a 100644
 +    PKGCONFIG += libsignon-qt5
 +}
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
-index 42c0151b..6c161169 100644
+index 4b65fc1e..88680e95 100644
 --- a/src/plugins/messageservices/imap/imap.pro
 +++ b/src/plugins/messageservices/imap/imap.pro
-@@ -10,6 +10,13 @@ contains(DEFINES,QT_QMF_USE_ALIGNEDTIMER) {
-     QT += alignedtimer
- }
+@@ -6,6 +6,13 @@ load(qt_plugin)
+ 
+ QT = core network qmfclient qmfclient-private qmfmessageserver
  
 +contains(DEFINES,USE_ACCOUNTS_QT) {
 +    CONFIG += link_pkgconfig
@@ -1256,10 +1248,10 @@ index 3a9bdf8d..02b3d67c 100644
  
  #endif
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 72a29ffe..0be2260b 100644
+index 2db0af46..4b0e627a 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -182,16 +182,23 @@ class IdleProtocol : public ImapProtocol {
+@@ -177,16 +177,23 @@ class IdleProtocol : public ImapProtocol {
      Q_OBJECT
  
  public:
@@ -1284,9 +1276,9 @@ index 72a29ffe..0be2260b 100644
  
  protected slots:
      virtual void idleContinuation(ImapCommand, const QString &);
-@@ -211,9 +218,22 @@ private:
+@@ -202,9 +209,22 @@ protected:
+ private:
      QTimer _idleTimer; // Send a DONE command every 29 minutes
- #endif
      QTimer _idleRecoveryTimer; // Check command hasn't hung
 +#ifdef USE_ACCOUNTS_QT
 +    int _idleRetryDelay; // Try to restablish IDLE state
@@ -1307,7 +1299,7 @@ index 72a29ffe..0be2260b 100644
  {
      _client = client;
      _folder = folder;
-@@ -310,14 +330,28 @@ void IdleProtocol::idleCommandTransition(const ImapCommand command, const Operat
+@@ -293,14 +313,28 @@ void IdleProtocol::idleCommandTransition(const ImapCommand command, const Operat
                      break;
                  }
              }
@@ -1337,7 +1329,7 @@ index 72a29ffe..0be2260b 100644
              break;
          }
          case IMAP_Login: // Fall through
-@@ -385,9 +419,23 @@ void IdleProtocol::idleErrorRecovery()
+@@ -368,9 +402,23 @@ void IdleProtocol::idleErrorRecovery()
      const int oneHour = 60*60;
      _idleRecoveryTimer.stop();
  
@@ -1363,7 +1355,7 @@ index 72a29ffe..0be2260b 100644
  }
  
  ImapClient::ImapClient(QObject* parent)
-@@ -400,6 +448,12 @@ ImapClient::ImapClient(QObject* parent)
+@@ -383,6 +431,12 @@ ImapClient::ImapClient(QObject* parent)
        _rapidClosing(false),
        _idleRetryDelay(InitialIdleRetryDelay),
        _pushConnectionsReserved(0)
@@ -1376,7 +1368,7 @@ index 72a29ffe..0be2260b 100644
  {
      static int count(0);
      ++count;
-@@ -449,6 +503,9 @@ ImapClient::ImapClient(QObject* parent)
+@@ -432,6 +486,9 @@ ImapClient::ImapClient(QObject* parent)
              this, SLOT(connectionInactive()));
  
      connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
@@ -1386,7 +1378,7 @@ index 72a29ffe..0be2260b 100644
  }
  
  ImapClient::~ImapClient()
-@@ -466,6 +523,10 @@ ImapClient::~ImapClient()
+@@ -449,6 +506,10 @@ ImapClient::~ImapClient()
          QMailMessageBuffer::instance()->removeCallback(callback);
      }
      delete _strategyContext;
@@ -1397,7 +1389,7 @@ index 72a29ffe..0be2260b 100644
  }
  
  // Called to begin executing a strategy
-@@ -539,8 +600,28 @@ void ImapClient::checkCommandResponse(ImapCommand command, OperationStatus statu
+@@ -522,8 +583,28 @@ void ImapClient::checkCommandResponse(ImapCommand command, OperationStatus statu
  
              case IMAP_Login:
              {
@@ -1426,7 +1418,7 @@ index 72a29ffe..0be2260b 100644
              }
  
              case IMAP_Full:
-@@ -571,6 +652,12 @@ void ImapClient::checkCommandResponse(ImapCommand command, OperationStatus statu
+@@ -554,6 +635,12 @@ void ImapClient::checkCommandResponse(ImapCommand command, OperationStatus statu
          case IMAP_Unconnected:
              operationFailed(QMailServiceAction::Status::ErrNoConnection, _protocol.lastError());
              return;
@@ -1439,7 +1431,7 @@ index 72a29ffe..0be2260b 100644
          default:
              break;
      }
-@@ -631,7 +718,15 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -614,7 +701,15 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                      }
                  }
                  emit updateStatus( tr("Logging in" ) );
@@ -1455,7 +1447,7 @@ index 72a29ffe..0be2260b 100644
              }
              break;
          }
-@@ -639,7 +734,15 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -622,7 +717,15 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
          case IMAP_Idle_Continuation:
          {
              emit updateStatus( tr("Logging in" ) );
@@ -1471,7 +1463,7 @@ index 72a29ffe..0be2260b 100644
              break;
          }
          
-@@ -678,9 +781,16 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -661,9 +764,16 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                  account.setStatus(QMailAccount::CanReferenceExternalData, supportsReferences);
                  imapCfg.setPushCapable(_protocol.supportsCapability("IDLE"));
                  imapCfg.setCapabilities(_protocol.capabilities());
@@ -1488,7 +1480,7 @@ index 72a29ffe..0be2260b 100644
              }
              // After logging in server capabilities reported may change so we need to
              // check if IDLE is already established, when enabled
-@@ -1489,6 +1599,24 @@ void ImapClient::setAccount(const QMailAccountId &id)
+@@ -1472,6 +1582,24 @@ void ImapClient::setAccount(const QMailAccountId &id)
              qMailLog(Messaging) << "Disable HasPersistentConnection for account" << account.id();
          }
      }
@@ -1497,10 +1489,10 @@ index 72a29ffe..0be2260b 100644
 +    if (!_ssoSessionManager) {
 +        _ssoSessionManager = new SSOSessionManager(this);
 +         if (_ssoSessionManager->createSsoIdentity(id, "imap4")) {
-+             ENFORCE(connect(_ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >))
-+                             ,this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >))));
-+             ENFORCE(connect(_ssoSessionManager, SIGNAL(ssoSessionError(QString))
-+                             ,this, SLOT(onSsoSessionError(QString))));
++             connect(_ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >)),
++                     this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >)));
++             connect(_ssoSessionManager, SIGNAL(ssoSessionError(QString)),
++                     this, SLOT(onSsoSessionError(QString)));
 +             qMailLog(IMAP) << Q_FUNC_INFO << "SSO identity is found for account id: "<< id;
 +         } else {
 +             delete _ssoSessionManager;
@@ -1513,7 +1505,7 @@ index 72a29ffe..0be2260b 100644
  }
  
  QMailAccountId ImapClient::account() const
-@@ -1522,6 +1650,11 @@ void ImapClient::transportStatus(const QString& status)
+@@ -1505,6 +1633,11 @@ void ImapClient::transportStatus(const QString& status)
  void ImapClient::cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text)
  {
      operationFailed(code, text);
@@ -1525,7 +1517,7 @@ index 72a29ffe..0be2260b 100644
  }
  
  void ImapClient::retrieveOperationCompleted()
-@@ -1650,6 +1783,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
+@@ -1633,6 +1766,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
      folder->setStatus(QMailFolder::PartialContent, (count < folder->serverCount()));
  }
  
@@ -1541,7 +1533,7 @@ index 72a29ffe..0be2260b 100644
  bool ImapClient::idlesEstablished()
  {
      ImapConfiguration imapCfg(_config);
-@@ -1708,27 +1850,39 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1691,27 +1833,39 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      foreach(QMailFolderId id, mailboxIds) {
          if (!_monitored.contains(id)) {
              ++count;
@@ -1588,7 +1580,7 @@ index 72a29ffe..0be2260b 100644
          return;
      }
      _protocol.close();
-@@ -1739,7 +1893,7 @@ void ImapClient::idleOpenRequested()
+@@ -1722,7 +1876,7 @@ void ImapClient::idleOpenRequested()
          delete protocol;
      }
      _idlesEstablished = false;
@@ -1597,7 +1589,7 @@ index 72a29ffe..0be2260b 100644
                     << "IDLE: IMAP IDLE error recovery trying to establish IDLE state now.";
      emit restartPushEmail();
  }
-@@ -1769,4 +1923,125 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1752,4 +1906,125 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -2285,7 +2277,7 @@ index a704ab57..419b9508 100644
  };
  
 diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index e605a34d..397566cc 100644
+index e605a34d..1be54f9a 100644
 --- a/src/plugins/messageservices/pop/popclient.cpp
 +++ b/src/plugins/messageservices/pop/popclient.cpp
 @@ -77,10 +77,18 @@ PopClient::PopClient(QObject* parent)
@@ -2326,7 +2318,7 @@ index e605a34d..397566cc 100644
      if (transport && transport->connected()) {
          if (selected) {
              // Re-use the existing connection
-@@ -252,6 +265,23 @@ void PopClient::setAccount(const QMailAccountId &id)
+@@ -252,6 +265,24 @@ void PopClient::setAccount(const QMailAccountId &id)
              qMailLog(POP) <<  "Flags for POP folder" << folder.id() << folder.path() << "updated";
          }
      }
@@ -2335,9 +2327,10 @@ index e605a34d..397566cc 100644
 +    if (!ssoSessionManager) {
 +        ssoSessionManager = new SSOSessionManager(this);
 +        if (ssoSessionManager->createSsoIdentity(id, "pop3")) {
-+            ENFORCE(connect(ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >))
-+                            ,this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >))));
-+            ENFORCE(connect(ssoSessionManager, SIGNAL(ssoSessionError(QString)),this, SLOT(onSsoSessionError(QString))));
++            connect(ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >)),
++                    this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >)));
++            connect(ssoSessionManager, SIGNAL(ssoSessionError(QString)),
++                    this, SLOT(onSsoSessionError(QString)));
 +            qMailLog(POP) << Q_FUNC_INFO << "SSO identity is found for account id: "<< id;
 +        } else {
 +            delete ssoSessionManager;
@@ -2350,7 +2343,7 @@ index e605a34d..397566cc 100644
  }
  
  QMailAccountId PopClient::accountId() const
-@@ -524,7 +554,21 @@ void PopClient::processResponse(const QString &response)
+@@ -524,7 +555,21 @@ void PopClient::processResponse(const QString &response)
      {
          if (response[0] != '+') {
              // Authentication failed
@@ -2372,7 +2365,7 @@ index e605a34d..397566cc 100644
          } else {
              if ((response.length() > 2) && (response[1] == ' ')) {
                  // This is a continuation containing a challenge string (in Base64)
-@@ -738,7 +782,11 @@ void PopClient::nextAction()
+@@ -738,7 +783,11 @@ void PopClient::nextAction()
          emit updateStatus(tr("Logging in"));
  
          // Get the login command sequence to use
@@ -2384,7 +2377,7 @@ index e605a34d..397566cc 100644
  
          nextStatus = Auth;
          nextCommand = authCommands.takeFirst();
-@@ -1236,6 +1284,11 @@ void PopClient::checkForNewMessages()
+@@ -1236,6 +1285,11 @@ void PopClient::checkForNewMessages()
  void PopClient::cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text)
  {
      operationFailed(code, text);
@@ -2396,7 +2389,7 @@ index e605a34d..397566cc 100644
  }
  
  void PopClient::retrieveOperationCompleted()
-@@ -1333,3 +1386,72 @@ void PopClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1333,3 +1387,72 @@ void PopClient::removeAllFromBuffer(QMailMessage *message)
          _bufferedMessages.remove(i);
      }
  }
@@ -2634,19 +2627,16 @@ index a987d84a..62f60541 100644
             smtpclient.h \
             smtpconfiguration.h \
 diff --git a/src/plugins/messageservices/smtp/smtpauthenticator.cpp b/src/plugins/messageservices/smtp/smtpauthenticator.cpp
-index 76fb904e..100bdc27 100644
+index 76fb904e..d1d5a2ff 100644
 --- a/src/plugins/messageservices/smtp/smtpauthenticator.cpp
 +++ b/src/plugins/messageservices/smtp/smtpauthenticator.cpp
-@@ -33,17 +33,124 @@
+@@ -36,14 +36,124 @@
+ #include "smtpconfiguration.h"
  
- #include "smtpauthenticator.h"
- 
--#include "smtpconfiguration.h"
--
  #include <qmailauthenticator.h>
--
 +#include <qmailstore.h>
 +#include <qmaillog.h>
+ 
  
  namespace {
  
@@ -2704,8 +2694,8 @@ index 76fb904e..100bdc27 100644
 +        qMailLog(SMTP) << "Failed to get authentication for method" << authType << "in account id:" << id;
 +    }
 +    return result;
-+}
-+
+ }
+ 
 +QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration::ServiceConfiguration &svcCfg, const QStringList &capabilities, const QMap<QString, QList<QByteArray> > &ssoLogin)
 +{
 +    QByteArray result;
@@ -2759,13 +2749,13 @@ index 76fb904e..100bdc27 100644
 +    }
 +#endif
 +    return result;
- }
- 
++}
++
 +#else
  QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration::ServiceConfiguration &svcCfg, const QStringList &capabilities)
  {
      QByteArray result(QMailAuthenticator::getAuthentication(svcCfg, capabilities));
-@@ -72,6 +179,7 @@ QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration:
+@@ -72,6 +182,7 @@ QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration:
      }
      return result;
  }
@@ -2773,7 +2763,7 @@ index 76fb904e..100bdc27 100644
  
  QByteArray SmtpAuthenticator::getResponse(const QMailAccountConfiguration::ServiceConfiguration &svcCfg, const QByteArray &challenge)
  {
-@@ -85,9 +193,14 @@ QByteArray SmtpAuthenticator::getResponse(const QMailAccountConfiguration::Servi
+@@ -85,9 +196,14 @@ QByteArray SmtpAuthenticator::getResponse(const QMailAccountConfiguration::Servi
          if (responses.isEmpty())
              gResponses.erase(it);
      } else {
@@ -2814,7 +2804,7 @@ index 97300b99..23f31cb2 100644
  };
  
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 7308ef81..358f7416 100644
+index 7308ef81..aff16aea 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -113,6 +113,11 @@ SmtpClient::SmtpClient(QObject* parent)
@@ -2840,7 +2830,7 @@ index 7308ef81..358f7416 100644
  }
  
  void SmtpClient::accountsUpdated(const QMailAccountIdList &ids)
-@@ -146,6 +155,22 @@ void SmtpClient::setAccount(const QMailAccountId &id)
+@@ -146,6 +155,23 @@ void SmtpClient::setAccount(const QMailAccountId &id)
  {
      // Load the current configuration for this account
      config = QMailAccountConfiguration(id);
@@ -2848,9 +2838,10 @@ index 7308ef81..358f7416 100644
 +    if (!ssoSessionManager) {
 +        ssoSessionManager = new SSOSessionManager(this);
 +        if (ssoSessionManager->createSsoIdentity(id, "smtp")) {
-+            ENFORCE(connect(ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >))
-+                            ,this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >))));
-+            ENFORCE(connect(ssoSessionManager, SIGNAL(ssoSessionError(QString)),this, SLOT(onSsoSessionError(QString))));
++            connect(ssoSessionManager, SIGNAL(ssoSessionResponse(QMap<QString,QList<QByteArray> >)),
++                    this, SLOT(onSsoSessionResponse(QMap<QString,QList<QByteArray> >)));
++            connect(ssoSessionManager, SIGNAL(ssoSessionError(QString)),
++                    this, SLOT(onSsoSessionError(QString)));
 +            qMailLog(SMTP) << Q_FUNC_INFO << "SSO identity is found for account id: "<< id;
 +        } else {
 +            delete ssoSessionManager;
@@ -2863,7 +2854,7 @@ index 7308ef81..358f7416 100644
  }
  
  QMailAccountId SmtpClient::account() const
-@@ -161,6 +186,15 @@ void SmtpClient::newConnection()
+@@ -161,6 +187,15 @@ void SmtpClient::newConnection()
      // in the account settings are being managed properly.
      config = QMailAccountConfiguration(config.id());
  
@@ -2879,7 +2870,7 @@ index 7308ef81..358f7416 100644
      if (sending) {
          operationFailed(QMailServiceAction::Status::ErrConnectionInUse, tr("Cannot send message; transport in use"));
          return;
-@@ -572,6 +606,31 @@ void SmtpClient::nextAction(const QString &response)
+@@ -572,6 +607,31 @@ void SmtpClient::nextAction(const QString &response)
          addressComponent = localAddress.toIPv4Address();
  
          // Find the authentication mode to use
@@ -2911,7 +2902,7 @@ index 7308ef81..358f7416 100644
          QByteArray authCmd(SmtpAuthenticator::getAuthentication(config.serviceConfiguration("smtp"), capabilities));
          if (!authCmd.isEmpty()) {
              sendCommand(authCmd);
-@@ -587,8 +646,40 @@ void SmtpClient::nextAction(const QString &response)
+@@ -587,8 +647,40 @@ void SmtpClient::nextAction(const QString &response)
              status = Authenticated;
              nextAction(QString());
          }
@@ -2952,7 +2943,7 @@ index 7308ef81..358f7416 100644
      case Authenticating:
      {
          if (responseCode == 334) {
-@@ -602,8 +693,9 @@ void SmtpClient::nextAction(const QString &response)
+@@ -602,8 +694,9 @@ void SmtpClient::nextAction(const QString &response)
                  bufferedResponse.clear();
                  return;
              } else {
@@ -2964,7 +2955,7 @@ index 7308ef81..358f7416 100644
              }
          } else if (responseCode == 235) {
              // We are now authenticated
-@@ -633,14 +725,29 @@ void SmtpClient::nextAction(const QString &response)
+@@ -633,14 +726,29 @@ void SmtpClient::nextAction(const QString &response)
          } else if (responseCode == 530) {
              operationFailed(QMailServiceAction::Status::ErrConfiguration, response);
          } else {
@@ -2995,7 +2986,7 @@ index 7308ef81..358f7416 100644
          if (mailItr == mailList.end()) {
              // Nothing to send
              status = Quit;
-@@ -894,6 +1001,10 @@ void SmtpClient::nextAction(const QString &response)
+@@ -894,6 +1002,10 @@ void SmtpClient::nextAction(const QString &response)
  void SmtpClient::cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text)
  {
      operationFailed(code, text);
@@ -3006,7 +2997,7 @@ index 7308ef81..358f7416 100644
  }
  
  void SmtpClient::messageProcessed(const QMailMessageId &id)
-@@ -1048,3 +1159,53 @@ void SmtpClient::stopTransferring()
+@@ -1048,3 +1160,53 @@ void SmtpClient::stopTransferring()
          status = Sent;
      }
  }

--- a/rpm/0005-Add-keepalive-timer-to-IMAP-IDLE-service.patch
+++ b/rpm/0005-Add-keepalive-timer-to-IMAP-IDLE-service.patch
@@ -12,7 +12,7 @@ DEFINES+=USE_KEEPALIVE
  3 files changed, 38 insertions(+)
 
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
-index 6c161169..be6ca85a 100644
+index 88680e95..04e64e63 100644
 --- a/src/plugins/messageservices/imap/imap.pro
 +++ b/src/plugins/messageservices/imap/imap.pro
 @@ -6,6 +6,10 @@ load(qt_plugin)
@@ -23,9 +23,9 @@ index 6c161169..be6ca85a 100644
 +    PKGCONFIG += keepalive
 +}
 +
- contains(DEFINES,QT_QMF_USE_ALIGNEDTIMER) {
-     QT += alignedtimer
- }
+ contains(DEFINES,USE_ACCOUNTS_QT) {
+     CONFIG += link_pkgconfig
+     QT += xml
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
 index 3660c2be..55c09d91 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp

--- a/rpm/0006-Use-Qt5-booster-to-save-memory.patch
+++ b/rpm/0006-Use-Qt5-booster-to-save-memory.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Use Qt5 booster to save memory.
 
 ---
  src/tools/messageserver/main.cpp                        | 2 +-
- src/tools/messageserver/messageserver.pro               | 6 ++++++
+ src/tools/messageserver/messageserver.pro               | 7 +++++++
  src/tools/systemd/messageserver5-accounts-check.service | 4 +++-
  src/tools/systemd/messageserver5.service                | 6 +++---
  src/tools/tools.pro                                     | 2 ++
- 5 files changed, 15 insertions(+), 5 deletions(-)
+ 5 files changed, 16 insertions(+), 5 deletions(-)
 
 diff --git a/src/tools/messageserver/main.cpp b/src/tools/messageserver/main.cpp
 index 9c107629..d9a35c53 100644
@@ -25,14 +25,15 @@ index 9c107629..d9a35c53 100644
  #ifdef USE_HTML_PARSER
      // Need for html parsing by <QTextdocument> in qmailmessage.cpp, but don't need real UI
 diff --git a/src/tools/messageserver/messageserver.pro b/src/tools/messageserver/messageserver.pro
-index 9ab48893..1950e68b 100644
+index 70b20f49..73482096 100644
 --- a/src/tools/messageserver/messageserver.pro
 +++ b/src/tools/messageserver/messageserver.pro
-@@ -17,6 +17,12 @@ contains(DEFINES, USE_HTML_PARSER) {
+@@ -11,6 +11,13 @@ contains(DEFINES, USE_HTML_PARSER) {
      QT += gui widgets
  }
  
 +packagesExist(qt5-boostable) {
++    CONFIG += link_pkgconfig
 +    PKGCONFIG += qt5-boostable
 +} else {
 +    warning("qt5-boostable not available; startup times will be slower")

--- a/rpm/0007-Recreate-SSO-identity-for-smtp-in-case-of-failure.patch
+++ b/rpm/0007-Recreate-SSO-identity-for-smtp-in-case-of-failure.patch
@@ -10,7 +10,7 @@ Similar to what is already done for IMAP.
  2 files changed, 12 insertions(+)
 
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 358f7416..3caac7f6 100644
+index aff16aea..5cb3df9d 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -117,6 +117,8 @@ SmtpClient::SmtpClient(QObject* parent)
@@ -22,7 +22,7 @@ index 358f7416..3caac7f6 100644
  #endif
  {
      connect(QMailStore::instance(), SIGNAL(accountsUpdated(const QMailAccountIdList&)), 
-@@ -663,6 +665,9 @@ void SmtpClient::nextAction(const QString &response)
+@@ -664,6 +666,9 @@ void SmtpClient::nextAction(const QString &response)
                      operationFailed(QMailServiceAction::Status::ErrLoginFailed, response);
                  }
              }
@@ -32,7 +32,7 @@ index 358f7416..3caac7f6 100644
          } else {
              if (!ssoSessionManager->waitForSso()) {
                  QByteArray authCmd(SmtpAuthenticator::getAuthentication(config.serviceConfiguration("smtp"), capabilities, ssoLogin));
-@@ -1188,6 +1193,8 @@ void SmtpClient::onSsoSessionResponse(const QMap<QString, QList<QByteArray> > &s
+@@ -1189,6 +1194,8 @@ void SmtpClient::onSsoSessionResponse(const QMap<QString, QList<QByteArray> > &s
          ssoLogin = ssoCredentials;
          if (sendLogin) {
              sendLogin = false;
@@ -41,7 +41,7 @@ index 358f7416..3caac7f6 100644
              QByteArray authCmd(SmtpAuthenticator::getAuthentication(config.serviceConfiguration("smtp"), capabilities, ssoLogin));
              if (!authCmd.isEmpty()) {
                  sendCommand(authCmd);
-@@ -1205,6 +1212,9 @@ void SmtpClient::onSsoSessionError(const QString &error)
+@@ -1206,6 +1213,9 @@ void SmtpClient::onSsoSessionError(const QString &error)
      // Reset vars
      loginFailed = false;
      sendLogin = false;

--- a/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -16,7 +16,7 @@ and activate/deactivate IMAP IDLE.
  6 files changed, 160 insertions(+), 26 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
-index be6ca85a..6a4e9adf 100644
+index 04e64e63..7d567a85 100644
 --- a/src/plugins/messageservices/imap/imap.pro
 +++ b/src/plugins/messageservices/imap/imap.pro
 @@ -8,6 +8,7 @@ QT = core network qmfclient qmfclient-private qmfmessageserver
@@ -26,12 +26,12 @@ index be6ca85a..6a4e9adf 100644
 +    QT += dbus
  }
  
- contains(DEFINES,QT_QMF_USE_ALIGNEDTIMER) {
+ contains(DEFINES,USE_ACCOUNTS_QT) {
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 0be2260b..5dac1a15 100644
+index 4b0e627a..891ce113 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -447,7 +447,8 @@ ImapClient::ImapClient(QObject* parent)
+@@ -430,7 +430,8 @@ ImapClient::ImapClient(QObject* parent)
        _requestRapidClose(false),
        _rapidClosing(false),
        _idleRetryDelay(InitialIdleRetryDelay),
@@ -41,7 +41,7 @@ index 0be2260b..5dac1a15 100644
  #ifdef USE_ACCOUNTS_QT
      , _ssoSessionManager(0),
        _loginFailed(false),
-@@ -699,7 +700,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -682,7 +683,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
              }
  
              // We are now connected
@@ -49,7 +49,7 @@ index 0be2260b..5dac1a15 100644
              _waitingForIdleFolderIds = configurationIdleFolderIds();
  
              if (!_idlesEstablished
-@@ -708,9 +708,17 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -691,9 +691,17 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                  && _pushConnectionsReserved) {
                  _waitingForIdle = true;
                  emit updateStatus( tr("Logging in idle connection" ) );
@@ -68,7 +68,7 @@ index 0be2260b..5dac1a15 100644
                      foreach(const QMailFolderId &id, _monitored.keys()) {
                          IdleProtocol *protocol = _monitored.take(id);
                          protocol->close();
-@@ -1794,8 +1802,7 @@ bool ImapClient::loggingIn() const
+@@ -1777,8 +1785,7 @@ bool ImapClient::loggingIn() const
  
  bool ImapClient::idlesEstablished()
  {
@@ -78,7 +78,7 @@ index 0be2260b..5dac1a15 100644
          return true;
  
      return _idlesEstablished;
-@@ -1818,8 +1825,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
+@@ -1801,8 +1808,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
  {
      ImapConfiguration imapCfg(_config);            
      QMailFolderIdList folderIds;
@@ -89,7 +89,7 @@ index 0be2260b..5dac1a15 100644
      foreach(QString folderName, imapCfg.pushFolders()) {
          QMailFolderId idleFolderId(mailboxId(folderName));
          if (idleFolderId.isValid()) {
-@@ -1835,7 +1843,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1818,7 +1826,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      
      ImapConfiguration imapCfg(_config);
      if (!_protocol.supportsCapability("IDLE")
@@ -98,7 +98,7 @@ index 0be2260b..5dac1a15 100644
          return;
      }
      
-@@ -1923,6 +1931,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1906,6 +1914,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -125,7 +125,7 @@ index 0be2260b..5dac1a15 100644
  #ifdef USE_ACCOUNTS_QT
  void ImapClient::removeSsoIdentity(const QMailAccountId &accountId)
  {
-@@ -1938,7 +1966,7 @@ void ImapClient::removeSsoIdentity(const QMailAccountId &accountId)
+@@ -1921,7 +1949,7 @@ void ImapClient::removeSsoIdentity(const QMailAccountId &accountId)
  
  void ImapClient::ssoProcessLogin()
  {
@@ -134,7 +134,7 @@ index 0be2260b..5dac1a15 100644
          // if account was updated try to recreate
          // identity without asking the user for new
          // credentials
-@@ -1979,6 +2007,8 @@ void ImapClient::onSsoSessionResponse(const QMap<QString,QList<QByteArray> > &ss
+@@ -1962,6 +1990,8 @@ void ImapClient::onSsoSessionResponse(const QMap<QString,QList<QByteArray> > &ss
      }
      if (_sendLogin) {
          _protocol.sendLogin(_config, _ssoLogin);
@@ -143,7 +143,7 @@ index 0be2260b..5dac1a15 100644
      }
  }
  
-@@ -2011,6 +2041,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+@@ -1994,6 +2024,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
          }
  
          qMailLog(IMAP) << Q_FUNC_INFO << imapCfg1.mailUserName() ;
@@ -158,7 +158,7 @@ index 0be2260b..5dac1a15 100644
          // compare config modified by the User
          const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
                                 (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-@@ -2018,15 +2056,19 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+@@ -2001,15 +2039,19 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
                                 (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
                                 (imapCfg1.mailEncryption() != imapCfg2.mailEncryption()) ||
                                 (imapCfg1.pushEnabled() != imapCfg2.pushEnabled());
@@ -178,7 +178,7 @@ index 0be2260b..5dac1a15 100644
  
  void ImapClient::closeIdleConnections()
  {
-@@ -2036,12 +2078,12 @@ void ImapClient::closeIdleConnections()
+@@ -2019,12 +2061,12 @@ void ImapClient::closeIdleConnections()
      // closing idle connections
      foreach(const QMailFolderId &id, _monitored.keys()) {
          IdleProtocol *protocol = _monitored.take(id);

--- a/rpm/0010-Add-signature-settings-in-account.patch
+++ b/rpm/0010-Add-signature-settings-in-account.patch
@@ -114,7 +114,7 @@ index 8ba3efa9..9306dd9c 100644
      void setLastSynchronized(const QMailTimeStamp &synced);
  
 diff --git a/src/libraries/qmfclient/qmailstore_p.cpp b/src/libraries/qmfclient/qmailstore_p.cpp
-index 6785f1f4..ea3c8cc0 100644
+index e6c51a1f..a3f9b814 100644
 --- a/src/libraries/qmfclient/qmailstore_p.cpp
 +++ b/src/libraries/qmfclient/qmailstore_p.cpp
 @@ -2675,6 +2675,10 @@ bool SSOAccountSatisfyTheProperty(Accounts::Account* ssoAccount, const QMailAcco

--- a/rpm/0011-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
+++ b/rpm/0011-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
@@ -16,10 +16,10 @@ Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index fd09753f..847cdc2d 100644
+index bfbd9417..a34a61e4 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
-@@ -1610,7 +1610,11 @@ namespace attachments
+@@ -1609,7 +1609,11 @@ namespace attachments
                  disposition.setParameter("filename*", QMailMessageContentDisposition::encodeParameter(input, "UTF-8"));
              }
  

--- a/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -72,7 +72,7 @@ index 9306dd9c..933cfa0c 100644
      void setStatus(quint64 newStatus);
      void setStatus(quint64 mask, bool set);
 diff --git a/src/libraries/qmfclient/qmailstore_p.cpp b/src/libraries/qmfclient/qmailstore_p.cpp
-index ea3c8cc0..9d74a874 100644
+index a3f9b814..ce8efe29 100644
 --- a/src/libraries/qmfclient/qmailstore_p.cpp
 +++ b/src/libraries/qmfclient/qmailstore_p.cpp
 @@ -3710,6 +3710,42 @@ bool QMailStorePrivate::messageExists(const QString &serveruid, const QMailAccou

--- a/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
+++ b/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
@@ -18,10 +18,10 @@ code which caused the database change, otherwise crashes can result
  6 files changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 5dac1a15..e4995480 100644
+index 891ce113..5d51085c 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -505,7 +505,8 @@ ImapClient::ImapClient(QObject* parent)
+@@ -488,7 +488,8 @@ ImapClient::ImapClient(QObject* parent)
  
      connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
  #ifdef USE_ACCOUNTS_QT
@@ -45,7 +45,7 @@ index e2d4a3d4..3e4dd422 100644
  
  #ifdef USE_KEEPALIVE
 diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index 397566cc..086b4f63 100644
+index 1be54f9a..13a52ca4 100644
 --- a/src/plugins/messageservices/pop/popclient.cpp
 +++ b/src/plugins/messageservices/pop/popclient.cpp
 @@ -87,7 +87,8 @@ PopClient::PopClient(QObject* parent)
@@ -72,7 +72,7 @@ index 8c661941..d80b3c39 100644
      _client.setAccount(accountId);
      QMailAccountConfiguration accountCfg(accountId);
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 3caac7f6..95440556 100644
+index 5cb3df9d..62256d3c 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -122,7 +122,7 @@ SmtpClient::SmtpClient(QObject* parent)

--- a/rpm/0017-Revert-Fix-bundled-zlib-detection.patch
+++ b/rpm/0017-Revert-Fix-bundled-zlib-detection.patch
@@ -12,10 +12,10 @@ qt gets updated.
  1 file changed, 11 insertions(+), 3 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
-index 6a4e9adf..a67092c7 100644
+index 7d567a85..ecb0621b 100644
 --- a/src/plugins/messageservices/imap/imap.pro
 +++ b/src/plugins/messageservices/imap/imap.pro
-@@ -61,9 +61,17 @@ SOURCES += imapclient.cpp \
+@@ -57,9 +57,17 @@ SOURCES += imapclient.cpp \
      RESOURCES += imap.qrc
  }
  

--- a/rpm/0018-Revert-Use-QRandomGenerator-instead-of-qrand.patch
+++ b/rpm/0018-Revert-Use-QRandomGenerator-instead-of-qrand.patch
@@ -11,7 +11,7 @@ This reverts commit 9c8962c1942eec471d495b3d11436087e7d46cdd.
  3 files changed, 31 insertions(+), 6 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index 038b5be9..4b81629e 100644
+index a34a61e4..fe780318 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
 @@ -53,7 +53,6 @@
@@ -22,7 +22,7 @@ index 038b5be9..4b81629e 100644
  #include <qtextstream.h>
  #include <QTextCodec>
  #include <QtDebug>
-@@ -7974,6 +7973,25 @@ uint QMailMessagePrivate::indicativeSize() const
+@@ -7976,6 +7975,25 @@ uint QMailMessagePrivate::indicativeSize() const
      return (size + 1);
  }
  
@@ -48,7 +48,7 @@ index 038b5be9..4b81629e 100644
  static QByteArray gBoundaryString;
  
  void QMF_EXPORT setQMailMessageBoundaryString(const QByteArray &boundary)
-@@ -7990,7 +8008,7 @@ static QByteArray boundaryString(const QByteArray &hash)
+@@ -7992,7 +8010,7 @@ static QByteArray boundaryString(const QByteArray &hash)
          return gBoundaryString;
  
      // Formulate a boundary that is very unlikely to clash with the content
@@ -79,7 +79,7 @@ index 60def58c..d5043ea5 100644
          if (r>57) r+=7;
          if (r>90) r+=6;
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 95440556..12cd1b23 100644
+index 62256d3c..daa63008 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -43,7 +43,6 @@

--- a/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -224,7 +224,7 @@ index 9522c05a..bbde2106 100644
          d->notifyMessageRemovalRecordsChange(type, idList);
  
 diff --git a/src/libraries/qmfclient/qmailstoreimplementation_p.cpp b/src/libraries/qmfclient/qmailstoreimplementation_p.cpp
-index 7ebabdb7..c80774ef 100644
+index 3c274119..0b18aaa5 100644
 --- a/src/libraries/qmfclient/qmailstoreimplementation_p.cpp
 +++ b/src/libraries/qmfclient/qmailstoreimplementation_p.cpp
 @@ -116,11 +116,11 @@ void emitIpcUpdates(MailstoreAdaptor &adaptor, const QMailMessageIdList& ids,  q
@@ -261,7 +261,7 @@ index 7ebabdb7..c80774ef 100644
          }
          data.clear();
      }
-@@ -312,7 +311,7 @@ void QMailStoreImplementationBase::notifyAccountsChange(QMailStore::ChangeType c
+@@ -315,7 +314,7 @@ void QMailStoreImplementationBase::notifyAccountsChange(QMailStore::ChangeType c
              flushTimer.start(flushTimeout);
          }
  
@@ -270,7 +270,7 @@ index 7ebabdb7..c80774ef 100644
          switch (changeType)
          {
          case QMailStore::Added:
-@@ -349,7 +348,7 @@ void QMailStoreImplementationBase::notifyMessagesChange(QMailStore::ChangeType c
+@@ -352,7 +351,7 @@ void QMailStoreImplementationBase::notifyMessagesChange(QMailStore::ChangeType c
              flushTimer.start(flushTimeout);
          }
  
@@ -279,7 +279,7 @@ index 7ebabdb7..c80774ef 100644
          switch (changeType)
          {
          case QMailStore::Added:
-@@ -415,7 +414,7 @@ void QMailStoreImplementationBase::notifyMessagesDataChange(const QMailMessageId
+@@ -418,7 +417,7 @@ void QMailStoreImplementationBase::notifyMessagesDataChange(const QMailMessageId
              flushTimer.start(flushTimeout);
          }
  
@@ -288,7 +288,7 @@ index 7ebabdb7..c80774ef 100644
          messagesPropertiesBuffer.append(props);;
  
      } else {
-@@ -435,7 +434,7 @@ void QMailStoreImplementationBase::notifyMessagesDataChange(const QMailMessageId
+@@ -438,7 +437,7 @@ void QMailStoreImplementationBase::notifyMessagesDataChange(const QMailMessageId
          }
  
          MessagesStatus messageStatus(status, set);
@@ -297,7 +297,7 @@ index 7ebabdb7..c80774ef 100644
  
      } else {
          emitIpcUpdates(*ipcAdaptor, ids, status, set, messageStatusUpdatedSig());
-@@ -455,7 +454,7 @@ void QMailStoreImplementationBase::notifyThreadsChange(QMailStore::ChangeType ch
+@@ -458,7 +457,7 @@ void QMailStoreImplementationBase::notifyThreadsChange(QMailStore::ChangeType ch
              flushTimer.start(flushTimeout);
          }
  
@@ -306,7 +306,7 @@ index 7ebabdb7..c80774ef 100644
          switch (changeType)
          {
          case QMailStore::Added:
-@@ -493,7 +492,7 @@ void QMailStoreImplementationBase::notifyFoldersChange(QMailStore::ChangeType ch
+@@ -496,7 +495,7 @@ void QMailStoreImplementationBase::notifyFoldersChange(QMailStore::ChangeType ch
              flushTimer.start(flushTimeout);
          }
  
@@ -315,7 +315,7 @@ index 7ebabdb7..c80774ef 100644
          switch (changeType)
          {
          case QMailStore::Added:
-@@ -530,7 +529,7 @@ void QMailStoreImplementationBase::notifyMessageRemovalRecordsChange(QMailStore:
+@@ -533,7 +532,7 @@ void QMailStoreImplementationBase::notifyMessageRemovalRecordsChange(QMailStore:
              flushTimer.start(flushTimeout);
          }
  
@@ -324,7 +324,7 @@ index 7ebabdb7..c80774ef 100644
          switch (changeType)
          {
          case QMailStore::Added:
-@@ -568,7 +567,7 @@ void QMailStoreImplementationBase::notifyTransmissionInProgress(const QMailAccou
+@@ -571,7 +570,7 @@ void QMailStoreImplementationBase::notifyTransmissionInProgress(const QMailAccou
  
  bool QMailStoreImplementationBase::setRetrievalInProgress(const QMailAccountIdList& ids)
  {
@@ -333,7 +333,7 @@ index 7ebabdb7..c80774ef 100644
      if ((idSet != retrievalInProgressIds) || !retrievalSetInitialized) {
          retrievalInProgressIds = idSet;
          retrievalSetInitialized = true;
-@@ -580,7 +579,7 @@ bool QMailStoreImplementationBase::setRetrievalInProgress(const QMailAccountIdLi
+@@ -583,7 +582,7 @@ bool QMailStoreImplementationBase::setRetrievalInProgress(const QMailAccountIdLi
  
  bool QMailStoreImplementationBase::setTransmissionInProgress(const QMailAccountIdList& ids)
  {

--- a/rpm/0020-Revert-Adjust-to-Qt6-QMetaType-API-changes.patch
+++ b/rpm/0020-Revert-Adjust-to-Qt6-QMetaType-API-changes.patch
@@ -10,7 +10,7 @@ This reverts commit f53c2885bff3408bf6aa8d89a9cb913980f51e9b.
  2 files changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailstore_p.cpp b/src/libraries/qmfclient/qmailstore_p.cpp
-index 9d74a874..05410d29 100644
+index ce8efe29..49922196 100644
 --- a/src/libraries/qmfclient/qmailstore_p.cpp
 +++ b/src/libraries/qmfclient/qmailstore_p.cpp
 @@ -3396,7 +3396,7 @@ static QString queryText(const QString &query, const QList<QVariant> &values)

--- a/rpm/0021-Revert-Replace-deprecated-QString-SplitBehavior.patch
+++ b/rpm/0021-Revert-Replace-deprecated-QString-SplitBehavior.patch
@@ -136,10 +136,10 @@ index 346dd7d3..7ef0989f 100644
          bool ok = false;
          int index = s.indexOf(":");
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 12cd1b23..b630de7d 100644
+index daa63008..b7a40fa0 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
-@@ -547,7 +547,7 @@ void SmtpClient::nextAction(const QString &response)
+@@ -548,7 +548,7 @@ void SmtpClient::nextAction(const QString &response)
                      QStringList authCaps;
                      foreach (QString const& capability, capabilities) {
                          if (capability.startsWith("AUTH", Qt::CaseInsensitive)) {

--- a/rpm/0023-Revert-core5compat-addition.patch
+++ b/rpm/0023-Revert-core5compat-addition.patch
@@ -10,7 +10,7 @@ Subject: [PATCH] Revert core5compat addition
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmfclient.pro b/src/libraries/qmfclient/qmfclient.pro
-index 6fedb7bd..88f543ce 100644
+index da650b33..c827d16f 100644
 --- a/src/libraries/qmfclient/qmfclient.pro
 +++ b/src/libraries/qmfclient/qmfclient.pro
 @@ -1,5 +1,5 @@

--- a/rpm/0026-Revert-Set-PLUGIN_CLASS_NAME-in-plugin-.pro-files.patch
+++ b/rpm/0026-Revert-Set-PLUGIN_CLASS_NAME-in-plugin-.pro-files.patch
@@ -15,7 +15,7 @@ This reverts commit 2051e62107bb25c43d228241a2e054c02d440d2f.
  7 files changed, 7 deletions(-)
 
 diff --git a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.pro b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.pro
-index a60b7ac4..d7720127 100644
+index 60fdd366..e34de9d4 100644
 --- a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.pro
 +++ b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.pro
 @@ -1,7 +1,6 @@
@@ -51,7 +51,7 @@ index 80e9d53d..257549b5 100644
  QT = core qmfclient
  
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
-index a67092c7..34fc4e92 100644
+index ecb0621b..87a9cc15 100644
 --- a/src/plugins/messageservices/imap/imap.pro
 +++ b/src/plugins/messageservices/imap/imap.pro
 @@ -1,7 +1,6 @@


### PR DESCRIPTION
Removed ENFORCE() usage which is removed upstream now. It was really just Q_ASSERT().

Added missing CONFIG += link_pkgconfig to messageserver. It was working by accident.

Common.pri removed so moved related content elsewhere.

Removed a bit of unnecessary #include delta to upstream.

cc @dcaliste 