### PR TITLE
[messagingframework] Remove unnecessary calls to accountsUpdated().

### DIFF
--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -94,13 +94,11 @@ base-qmf-oauth2-plugin/oauth2plugin.cpp
  src/plugins/credentials/sso/sso.pro           |    2 +-
  .../messageservices/imap/imapclient.cpp       |   39 +
  src/plugins/messageservices/imap/imapclient.h |    4 +
- src/plugins/messageservices/pop/popclient.cpp |   17 +
- src/plugins/messageservices/pop/popclient.h   |    4 +
  src/plugins/plugins.pro                       |    4 +
  src/tools/messageserver/servicehandler.cpp    |   13 +
  tests/tests.pri                               |    6 +
  tests/tst_qmailstore/tst_qmailstore.cpp       |   93 +-
- 16 files changed, 1661 insertions(+), 67 deletions(-)
+ 14 files changed, 1640 insertions(+), 67 deletions(-)
  create mode 100644 src/libraries/qmfclient/share/email.provider
  create mode 100644 src/libraries/qmfclient/share/email.service
 
@@ -2122,20 +2120,20 @@ index 9abae1c7..ac8c2902 100644
  HEADERS += plugin.h \
             ssomanager.h
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index c9bb6f94..6e997893 100644
+index 4aaa48a1..bef0b027 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -435,6 +435,9 @@ ImapClient::ImapClient(QObject* parent)
-             this, SLOT(connectionInactive()));
- 
+@@ -438,6 +438,9 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
      connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
+ 
+     setupAccount();
 +#ifdef USE_ACCOUNTS_QT
 +    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
 +#endif
  }
  
  ImapClient::~ImapClient()
-@@ -1814,4 +1817,40 @@ void ImapClient::onCredentialsStatusChanged()
+@@ -1807,4 +1810,56 @@ void ImapClient::onCredentialsStatusChanged()
      }
  }
  
@@ -2175,12 +2173,36 @@ index c9bb6f94..6e997893 100644
 +    }
 +}
 +
++void ImapClient::closeIdleConnections()
++{
++    qMailLog(IMAP) << Q_FUNC_INFO << "Account was modified. Closing connections";
++
++    closeConnection();
++    // closing idle connections
++    foreach(const QMailFolderId &id, _monitored.keys()) {
++        IdleProtocol *protocol = _monitored.take(id);
++        if (protocol->inUse()) {
++            protocol->close();
++        }
++        delete protocol;
++    }
++    _idlesEstablished = false;
++}
++
  #include "imapclient.moc"
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index e568ce84..f7029514 100644
+index dbf5abec..64cb362f 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -145,6 +145,10 @@ protected slots:
+@@ -67,6 +67,7 @@ public:
+     void newConnection();
+     void cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text);
+     void closeConnection();
++    void closeIdleConnections();
+ 
+     ImapStrategyContext *strategyContext();
+ 
+@@ -144,6 +144,10 @@ protected slots:
      void messageBufferFlushed();
      void onCredentialsStatusChanged();
  
@@ -2191,53 +2213,6 @@ index e568ce84..f7029514 100644
  private:
      friend class ImapStrategyContextBase;
  
-diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index 6843889c..966fe609 100644
---- a/src/plugins/messageservices/pop/popclient.cpp
-+++ b/src/plugins/messageservices/pop/popclient.cpp
-@@ -83,6 +83,9 @@ PopClient::PopClient(QObject* parent)
-     inactiveTimer.setSingleShot(true);
-     connect(&inactiveTimer, SIGNAL(timeout()), this, SLOT(connectionInactive()));
-     connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
-+#ifdef USE_ACCOUNTS_QT
-+    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
-+#endif
- }
- 
- PopClient::~PopClient()
-@@ -1372,3 +1375,17 @@ void PopClient::onCredentialsStatusChanged()
-                this, &PopClient::onCredentialsStatusChanged);
-     nextAction();
- }
-+
-+#ifdef USE_ACCOUNTS_QT
-+void PopClient::onAccountsUpdated(const QMailAccountIdList &list)
-+{
-+    if (!list.contains(accountId()))
-+        return;
-+
-+    QMailAccount acc(accountId());
-+    bool isEnabled(acc.status() & QMailAccount::Enabled);
-+    if (!isEnabled)
-+        return;
-+    setAccount(accountId());
-+}
-+#endif
-diff --git a/src/plugins/messageservices/pop/popclient.h b/src/plugins/messageservices/pop/popclient.h
-index ca7054b3..9edc1656 100644
---- a/src/plugins/messageservices/pop/popclient.h
-+++ b/src/plugins/messageservices/pop/popclient.h
-@@ -102,6 +102,10 @@ protected slots:
-     void connected(QMailTransport::EncryptType encryptType);
-     void transportError(int, QString msg);
- 
-+#ifdef USE_ACCOUNTS_QT
-+    void onAccountsUpdated(const QMailAccountIdList& list);
-+#endif
-+
-     void onCredentialsStatusChanged();
- 
-     void connectionInactive();
 diff --git a/src/plugins/plugins.pro b/src/plugins/plugins.pro
 index 6c9464c2..a647ade7 100644
 --- a/src/plugins/plugins.pro

--- a/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
+++ b/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Use a specific retry delay for IMAP idle connections.
  2 files changed, 23 insertions(+), 11 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 6e997893..e7f0399b 100644
+index bef0b027..344d2ab5 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -182,11 +182,12 @@ public:
@@ -55,8 +55,8 @@ index 6e997893..e7f0399b 100644
 -    emit openRequest();
  }
  
- ImapClient::ImapClient(QObject* parent)
-@@ -1743,20 +1755,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
+@@ -1736,20 +1748,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
                      this, SIGNAL(idleNewMailNotification(QMailFolderId)));
              connect(protocol, SIGNAL(idleFlagsChangedNotification(QMailFolderId)),
                      this, SIGNAL(idleFlagsChangedNotification(QMailFolderId)));
@@ -85,10 +85,10 @@ index 6e997893..e7f0399b 100644
      }
      _protocol.close();
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index f7029514..7d8ac008 100644
+index 64cb362f..64b5fe8f 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -141,7 +141,7 @@ protected slots:
+@@ -140,7 +140,7 @@ protected slots:
      void checkCommandResponse(const ImapCommand, const OperationStatus);
      void commandTransition(const ImapCommand, const OperationStatus);
      void transportStatus(const QString& status);

--- a/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
+++ b/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] Don't save settings during IMAP logging in.
  5 files changed, 41 insertions(+), 12 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index e7f0399b..02dce5b8 100644
+index 344d2ab5..bafef831 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -1690,6 +1690,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
+@@ -1683,6 +1683,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
      folder->setStatus(QMailFolder::PartialContent, (count < folder->serverCount()));
  }
  
@@ -31,7 +31,7 @@ index e7f0399b..02dce5b8 100644
  bool ImapClient::idlesEstablished()
  {
      ImapConfiguration imapCfg(_config);
-@@ -1779,7 +1788,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
+@@ -1772,7 +1781,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
          delete protocol;
      }
      _idlesEstablished = false;
@@ -41,10 +41,10 @@ index e7f0399b..02dce5b8 100644
      emit restartPushEmail();
  }
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 7d8ac008..490d64cf 100644
+index 64b5fe8f..8362043d 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -84,6 +84,7 @@ public:
+@@ -83,6 +83,7 @@ public:
      QMailMessageKey trashKey(const QMailFolderId &folderId) const;
      QStringList deletedMessages(const QMailFolderId &folderId) const;
  
@@ -81,10 +81,10 @@ index 8f014828..70ccbd91 100644
  
      bool delimiterUnknown() const;
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index e6fe5ec4..b1831448 100644
+index 76c8e2a4..ac9e5033 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
-@@ -1565,6 +1565,10 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1564,6 +1564,10 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      bool isPushEnabled(imapCfg.pushEnabled());
      QStringList pushFolders(imapCfg.pushFolders());
      QString newConnectionSettings(connectionSettings(imapCfg));
@@ -95,7 +95,7 @@ index e6fe5ec4..b1831448 100644
      if (!isEnabled) {
          if (_accountWasEnabled) {
              // Account changed from enabled to disabled
-@@ -1575,18 +1579,27 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1574,18 +1578,27 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
          return;
      }
  

--- a/rpm/0006-Add-keepalive-timer-to-IMAP-IDLE-service.patch
+++ b/rpm/0006-Add-keepalive-timer-to-IMAP-IDLE-service.patch
@@ -27,7 +27,7 @@ index 4b65fc1e..03c19785 100644
             imapconfiguration.h \
             imapmailboxproperties.h \
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index b1831448..01d18717 100644
+index ac9e5033..e98d498f 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1473,6 +1473,12 @@ ImapService::ImapService(const QMailAccountId &accountId)
@@ -43,7 +43,7 @@ index b1831448..01d18717 100644
      QMailAccount account(accountId);
      if (!(account.status() & QMailAccount::CanSearchOnServer)) {
          account.setStatus(QMailAccount::CanSearchOnServer, true);
-@@ -1880,7 +1886,24 @@ void ImapService::setPersistentConnectionStatus(bool status)
+@@ -1879,7 +1885,24 @@ void ImapService::setPersistentConnectionStatus(bool status)
          }
      }
      _idling = status;

--- a/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -28,18 +28,18 @@ index 03c19785..18608bae 100644
  
  HEADERS += imapclient.h \
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 02dce5b8..69313fbb 100644
+index bafef831..e71325f2 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -396,6 +396,7 @@ ImapClient::ImapClient(QObject* parent)
+@@ -397,6 +397,7 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
        _rapidClosing(false),
        _idleRetryDelay(InitialIdleRetryDelay),
        _pushConnectionsReserved(0),
 +      _pushEnabled(0),
-       _credentials(nullptr),
+       _credentials(QMailCredentialsFactory::getCredentialsHandlerForAccount(_config)),
        _loginFailed(false)
  {
-@@ -630,7 +631,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -633,7 +634,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
              }
  
              // We are now connected
@@ -47,7 +47,7 @@ index 02dce5b8..69313fbb 100644
              _waitingForIdleFolderIds = configurationIdleFolderIds();
  
              if (!_idlesEstablished
-@@ -641,7 +641,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -644,7 +644,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                  emit updateStatus( tr("Logging in idle connection" ) );
                  monitor(_waitingForIdleFolderIds);
              } else {
@@ -56,7 +56,7 @@ index 02dce5b8..69313fbb 100644
                      foreach(const QMailFolderId &id, _monitored.keys()) {
                          IdleProtocol *protocol = _monitored.take(id);
                          protocol->close();
-@@ -1701,8 +1701,7 @@ bool ImapClient::loggingIn() const
+@@ -1694,8 +1694,7 @@ bool ImapClient::loggingIn() const
  
  bool ImapClient::idlesEstablished()
  {
@@ -66,7 +66,7 @@ index 02dce5b8..69313fbb 100644
          return true;
  
      return _idlesEstablished;
-@@ -1725,8 +1724,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
+@@ -1718,8 +1717,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
  {
      ImapConfiguration imapCfg(_config);            
      QMailFolderIdList folderIds;
@@ -77,7 +77,7 @@ index 02dce5b8..69313fbb 100644
      foreach(QString folderName, imapCfg.pushFolders()) {
          QMailFolderId idleFolderId(mailboxId(folderName));
          if (idleFolderId.isValid()) {
-@@ -1742,7 +1742,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1735,7 +1735,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      
      ImapConfiguration imapCfg(_config);
      if (!_protocol.supportsCapability("IDLE")
@@ -86,7 +86,7 @@ index 02dce5b8..69313fbb 100644
          return;
      }
      
-@@ -1818,6 +1818,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1811,6 +1811,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -113,7 +113,7 @@ index 02dce5b8..69313fbb 100644
  void ImapClient::onCredentialsStatusChanged()
  {
      qMailLog(IMAP)  << "Got credential status changed" << _credentials->status();
-@@ -1857,6 +1877,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+@@ -1850,6 +1870,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
          }
  
          qMailLog(IMAP) << Q_FUNC_INFO << imapCfg1.mailUserName() ;
@@ -128,7 +128,7 @@ index 02dce5b8..69313fbb 100644
          // compare config modified by the User
          const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
                                 (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-@@ -1864,14 +1892,33 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+@@ -1857,13 +1885,16 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
                                 (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
                                 (imapCfg1.mailEncryption() != imapCfg2.mailEncryption()) ||
                                 (imapCfg1.pushEnabled() != imapCfg2.pushEnabled());
@@ -145,36 +145,11 @@ index 02dce5b8..69313fbb 100644
      }
  }
  
-+void ImapClient::closeIdleConnections()
-+{
-+    qMailLog(IMAP) << Q_FUNC_INFO << "Account was modified. Closing connections";
-+
-+    closeConnection();
-+    // closing idle connections
-+    foreach(const QMailFolderId &id, _monitored.keys()) {
-+        IdleProtocol *protocol = _monitored.take(id);
-+        if (protocol->inUse()) {
-+            protocol->close();
-+        }
-+        delete protocol;
-+    }
-+    _idlesEstablished = false;
-+}
-+
- #include "imapclient.moc"
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 490d64cf..47f12146 100644
+index 8362043d..e49f18e1 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -68,6 +68,7 @@ public:
-     void newConnection();
-     void cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text);
-     void closeConnection();
-+    void closeIdleConnections();
- 
-     ImapStrategyContext *strategyContext();
- 
-@@ -94,6 +95,8 @@ public:
+@@ -93,6 +94,8 @@ public:
      void setPushConnectionsReserved(int reserved) { _pushConnectionsReserved = reserved; }
      int idleRetryDelay() const { return _idleRetryDelay; }
      void setIdleRetryDelay(int delay) { _idleRetryDelay = delay; }
@@ -192,7 +167,7 @@ index 490d64cf..47f12146 100644
      QMultiMap<QMailMessageId,QString> detachedTempFiles;
  
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 01d18717..90f0d21e 100644
+index e98d498f..03fa2143 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -46,6 +46,12 @@
@@ -246,7 +221,7 @@ index 01d18717..90f0d21e 100644
  }
  
  void ImapService::enable()
-@@ -1512,15 +1530,32 @@ void ImapService::enable()
+@@ -1511,15 +1529,32 @@ void ImapService::enable()
  
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
@@ -282,7 +257,7 @@ index 01d18717..90f0d21e 100644
          if (!_initiatePushDelay.contains(_accountId)) {
              _initiatePushDelay.insert(_accountId, 0);
          } else if (_initiatePushDelay[_accountId] == 0) {
-@@ -1546,7 +1581,7 @@ void ImapService::disable()
+@@ -1545,7 +1580,7 @@ void ImapService::disable()
      _initiatePushEmailTimer->stop();
      setPersistentConnectionStatus(false);
      _accountWasEnabled = false;
@@ -291,7 +266,7 @@ index 01d18717..90f0d21e 100644
      _previousPushFolders = imapCfg.pushFolders();
      _previousConnectionSettings = connectionSettings(imapCfg);
      _source->setIntervalTimer(0);
-@@ -1568,7 +1603,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1567,7 +1602,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
      bool isEnabled(account.status() & QMailAccount::Enabled);
@@ -300,7 +275,7 @@ index 01d18717..90f0d21e 100644
      QStringList pushFolders(imapCfg.pushFolders());
      QString newConnectionSettings(connectionSettings(imapCfg));
      bool loggingIn = false;
-@@ -1603,7 +1638,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1602,7 +1637,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
          }
      } else {
          // Update the settings
@@ -309,7 +284,7 @@ index 01d18717..90f0d21e 100644
          _previousPushFolders = imapCfg.pushFolders();
          _previousConnectionSettings = connectionSettings(imapCfg);
      }
-@@ -1679,6 +1714,12 @@ void ImapService::initiatePushEmail()
+@@ -1678,6 +1713,12 @@ void ImapService::initiatePushEmail()
  
      qMailLog(Messaging) << "Attempting to establish push email for account" << _accountId
                          << QMailAccount(_accountId).name();
@@ -322,7 +297,7 @@ index 01d18717..90f0d21e 100644
      QMailFolderIdList ids(_client->configurationIdleFolderIds());
      if (ids.count()) {
          _establishingPushEmail = true;
-@@ -1731,6 +1772,18 @@ void ImapService::updateStatus(const QString &text)
+@@ -1730,6 +1771,18 @@ void ImapService::updateStatus(const QString &text)
      updateStatus(QMailServiceAction::Status::ErrNoError, text, _accountId);
  }
  
@@ -341,7 +316,7 @@ index 01d18717..90f0d21e 100644
  void ImapService::createIdleSession()
  {
      // Fail after 10 sec if no network reply is received
-@@ -1866,9 +1919,15 @@ void ImapService::onSessionConnectionTimeout()
+@@ -1865,9 +1918,15 @@ void ImapService::onSessionConnectionTimeout()
  
  bool ImapService::accountPushEnabled()
  {
@@ -358,7 +333,7 @@ index 01d18717..90f0d21e 100644
  }
  
  void ImapService::setPersistentConnectionStatus(bool status)
-@@ -1903,6 +1962,31 @@ void ImapService::startStopBackgroundActivity()
+@@ -1902,6 +1961,31 @@ void ImapService::startStopBackgroundActivity()
          _backgroundActivity->stop();
      }
  }

--- a/rpm/0009-Prevent-push-enabled-status-to-go-out-of-sync.patch
+++ b/rpm/0009-Prevent-push-enabled-status-to-go-out-of-sync.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Prevent push enabled status to go out of sync.
  1 file changed, 33 insertions(+), 24 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 90f0d21e..04a62a7c 100644
+index 03fa2143..c92a5f5d 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -64,7 +64,10 @@ QString connectionSettings(ImapConfiguration &config)
@@ -43,7 +43,7 @@ index 90f0d21e..04a62a7c 100644
  
      if(!m_dBusConnection.isConnected()) {
          qWarning() << Q_FUNC_INFO << "Cannot connect to Dbus";
-@@ -1532,22 +1538,19 @@ void ImapService::enable()
+@@ -1531,22 +1537,19 @@ void ImapService::enable()
      ImapConfiguration imapCfg(accountCfg);
      bool pushEnabled = accountPushEnabled();
  #ifdef USE_KEEPALIVE
@@ -69,7 +69,7 @@ index 90f0d21e..04a62a7c 100644
      _previousPushFolders = imapCfg.pushFolders();
      _previousConnectionSettings = connectionSettings(imapCfg);
      
-@@ -1610,6 +1613,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1609,6 +1612,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      if (_client) {
          loggingIn = _client->loggingIn();
      }
@@ -77,7 +77,7 @@ index 90f0d21e..04a62a7c 100644
      if (!isEnabled) {
          if (_accountWasEnabled) {
              // Account changed from enabled to disabled
-@@ -1717,7 +1721,7 @@ void ImapService::initiatePushEmail()
+@@ -1716,7 +1720,7 @@ void ImapService::initiatePushEmail()
  #ifdef USE_KEEPALIVE
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
@@ -86,7 +86,7 @@ index 90f0d21e..04a62a7c 100644
      _previousPushFolders = imapCfg.pushFolders();
  #endif
      QMailFolderIdList ids(_client->configurationIdleFolderIds());
-@@ -1967,23 +1971,28 @@ void ImapService::pushEnabledStatus(uint accountId, const QString &profileType,
+@@ -1966,23 +1970,28 @@ void ImapService::pushEnabledStatus(uint accountId, const QString &profileType,
  {
      qMailLog(Messaging) << "Received new idleState for account: " << accountId << "state: " << state << "profile type: " << profileType;
      if (accountId == _accountId.toULongLong() && profileType == QLatin1String("syncemail")) {

--- a/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -172,7 +172,7 @@ index e8563c39..3a41a1c1 100644
  #endif
  
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 04a62a7c..89831407 100644
+index c92a5f5d..26ba5610 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -235,7 +235,7 @@ bool ImapService::Source::retrieveFolderList(const QMailAccountId &accountId, co
@@ -352,7 +352,7 @@ index 4880b2b1..9a79e4b7 100644
      uint _total;
  };
 diff --git a/src/plugins/messageservices/pop/popservice.cpp b/src/plugins/messageservices/pop/popservice.cpp
-index 32b234d4..98be8300 100644
+index 56743f80..ef7cbf45 100644
 --- a/src/plugins/messageservices/pop/popservice.cpp
 +++ b/src/plugins/messageservices/pop/popservice.cpp
 @@ -103,6 +103,7 @@ private:

--- a/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
+++ b/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
@@ -11,18 +11,16 @@ code which caused the database change, otherwise crashes can result
 ---
  src/plugins/messageservices/imap/imapclient.cpp  | 3 ++-
  src/plugins/messageservices/imap/imapservice.cpp | 2 +-
- src/plugins/messageservices/pop/popclient.cpp    | 3 ++-
  src/plugins/messageservices/pop/popservice.cpp   | 2 +-
- src/plugins/messageservices/smtp/smtpclient.cpp  | 2 +-
- 5 files changed, 7 insertions(+), 5 deletions(-)
+ 3 files changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 69313fbb..3db91fca 100644
+index e71325f2..894feb08 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -449,7 +449,8 @@ ImapClient::ImapClient(QObject* parent)
+@@ -452,7 +452,8 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
  
-     connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
+     setupAccount();
  #ifdef USE_ACCOUNTS_QT
 -    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
 +    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)),
@@ -31,7 +29,7 @@ index 69313fbb..3db91fca 100644
  }
  
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 89831407..3376fcd4 100644
+index 26ba5610..be9bbd32 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1508,7 +1508,7 @@ ImapService::ImapService(const QMailAccountId &accountId)
@@ -43,22 +41,8 @@ index 89831407..3376fcd4 100644
      connect(_initiatePushEmailTimer, SIGNAL(timeout()), this, SLOT(initiatePushEmail()));
  
  #ifdef USE_KEEPALIVE
-diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index 966fe609..32010a8e 100644
---- a/src/plugins/messageservices/pop/popclient.cpp
-+++ b/src/plugins/messageservices/pop/popclient.cpp
-@@ -84,7 +84,8 @@ PopClient::PopClient(QObject* parent)
-     connect(&inactiveTimer, SIGNAL(timeout()), this, SLOT(connectionInactive()));
-     connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
- #ifdef USE_ACCOUNTS_QT
--    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
-+    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)),
-+            this, SLOT(onAccountsUpdated(QMailAccountIdList)), Qt::QueuedConnection);
- #endif
- }
- 
 diff --git a/src/plugins/messageservices/pop/popservice.cpp b/src/plugins/messageservices/pop/popservice.cpp
-index 98be8300..b8215eb3 100644
+index ef7cbf45..bb1fbc5f 100644
 --- a/src/plugins/messageservices/pop/popservice.cpp
 +++ b/src/plugins/messageservices/pop/popservice.cpp
 @@ -328,7 +328,7 @@ PopService::PopService(const QMailAccountId &accountId)
@@ -68,5 +52,5 @@ index 98be8300..b8215eb3 100644
 -            this, SLOT(accountsUpdated(const QMailAccountIdList&)));
 +            this, SLOT(accountsUpdated(const QMailAccountIdList&)), Qt::QueuedConnection);
  
-     _client.setAccount(accountId);
      QMailAccountConfiguration accountCfg(accountId);
+     PopConfiguration popCfg(accountCfg);

--- a/rpm/0016-Adjust-for-Qt-5.6.patch
+++ b/rpm/0016-Adjust-for-Qt-5.6.patch
@@ -31,10 +31,10 @@ index 6f603653..481a1f4d 100644
      connect(mSocket, &QAbstractSocket::bytesWritten, this, &QMailTransport::bytesWritten);
  
 diff --git a/tests/tst_smtp/tst_smtp.cpp b/tests/tst_smtp/tst_smtp.cpp
-index 74360d1a..ebeaa0cf 100644
+index 8dcfbe3a..7defc685 100644
 --- a/tests/tst_smtp/tst_smtp.cpp
 +++ b/tests/tst_smtp/tst_smtp.cpp
-@@ -99,9 +99,9 @@ void tst_SmtpClient::test_connection()
+@@ -98,9 +98,9 @@ void tst_SmtpClient::test_connection()
      QVERIFY(completed.wait());
  
      QCOMPARE(updateStatus.count(), 3);
@@ -47,7 +47,7 @@ index 74360d1a..ebeaa0cf 100644
  }
  
  void tst_SmtpClient::test_auth()
-@@ -120,9 +120,9 @@ void tst_SmtpClient::test_auth()
+@@ -119,9 +119,9 @@ void tst_SmtpClient::test_auth()
      QVERIFY(!completed.wait(250)); // Fails with wrong credentials
  
      QCOMPARE(updateStatus.count(), 3);
@@ -60,7 +60,7 @@ index 74360d1a..ebeaa0cf 100644
  
      smtp.setSmtpAuthentication(QMail::PlainMechanism);
      QVERIFY(QMailStore::instance()->updateAccountConfiguration(&config));
-@@ -131,7 +131,7 @@ void tst_SmtpClient::test_auth()
+@@ -130,7 +130,7 @@ void tst_SmtpClient::test_auth()
      QVERIFY(!completed.wait(250)); // Fails with wrong credentials
  
      QCOMPARE(updateStatus.count(), 3);

--- a/rpm/0018-Revert-Use-QRandomGenerator-instead-of-qrand.patch
+++ b/rpm/0018-Revert-Use-QRandomGenerator-instead-of-qrand.patch
@@ -79,7 +79,7 @@ index 60def58c..d5043ea5 100644
          if (r>57) r+=7;
          if (r>90) r+=6;
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 69e5d351..2033e669 100644
+index 2ec306b9..7203858c 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -43,7 +43,6 @@

--- a/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -343,7 +343,7 @@ index 3c274119..0b18aaa5 100644
          transmissionInProgressIds = idSet;
          transmissionSetInitialized = true;
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 3376fcd4..500437cd 100644
+index be9bbd32..215c4c00 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1240,7 +1240,7 @@ bool ImapService::Source::prepareMessages(const QList<QPair<QMailMessagePart::Lo

--- a/rpm/0021-Revert-Replace-deprecated-QString-SplitBehavior.patch
+++ b/rpm/0021-Revert-Replace-deprecated-QString-SplitBehavior.patch
@@ -136,10 +136,10 @@ index 346dd7d3..7ef0989f 100644
          bool ok = false;
          int index = s.indexOf(":");
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 2033e669..5d9ca89f 100644
+index 7203858c..406c3d5a 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
-@@ -561,7 +561,7 @@ void SmtpClient::nextAction(const QString &response)
+@@ -533,7 +533,7 @@ void SmtpClient::nextAction(const QString &response)
                      QStringList authCaps;
                      foreach (QString const& capability, capabilities) {
                          if (capability.startsWith("AUTH", Qt::CaseInsensitive)) {


### PR DESCRIPTION
Now that setAccount() in SMTP/POP/IMAP clients is not used anymore to reset the configuration (since configuration is reloaded on any new connection), there is no need to call setAccount() on account change.

One upstream patch forbids this by setting the account on construction. This simplifies a bit further the existing patch for Sailfish OS related to libaccount integration.