### PR TITLE
[messagingframework] Don't fail IDLE authentication.

### DIFF
--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -2120,10 +2120,10 @@ index 9abae1c7..ac8c2902 100644
  HEADERS += plugin.h \
             ssomanager.h
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 26ad7138..64a1613a 100644
+index 13c3184c..29aae0f4 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -1837,4 +1837,20 @@ void ImapClient::onCredentialsStatusChanged()
+@@ -1841,4 +1841,20 @@ void ImapClient::onCredentialsStatusChanged()
      }
  }
  

--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -92,13 +92,13 @@ base-qmf-oauth2-plugin/oauth2plugin.cpp
  src/libraries/qmfclient/share/email.service   |   65 +
  src/plugins/credentials/sso/plugin.cpp        |  123 +-
  src/plugins/credentials/sso/sso.pro           |    2 +-
- .../messageservices/imap/imapclient.cpp       |   55 +
- src/plugins/messageservices/imap/imapclient.h |    5 +
+ .../messageservices/imap/imapclient.cpp       |   16 +
+ src/plugins/messageservices/imap/imapclient.h |    1 +
  src/plugins/plugins.pro                       |    4 +
  src/tools/messageserver/servicehandler.cpp    |   13 +
  tests/tests.pri                               |    6 +
  tests/tst_qmailstore/tst_qmailstore.cpp       |   93 +-
- 14 files changed, 1657 insertions(+), 67 deletions(-)
+ 14 files changed, 1614 insertions(+), 67 deletions(-)
  create mode 100644 src/libraries/qmfclient/share/email.provider
  create mode 100644 src/libraries/qmfclient/share/email.service
 
@@ -2120,59 +2120,13 @@ index 9abae1c7..ac8c2902 100644
  HEADERS += plugin.h \
             ssomanager.h
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 26ad7138..fb75e7c0 100644
+index 26ad7138..64a1613a 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -473,6 +473,9 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
-     connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
- 
-     setupAccount();
-+#ifdef USE_ACCOUNTS_QT
-+    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
-+#endif
- }
- 
- ImapClient::~ImapClient()
-@@ -1837,4 +1840,56 @@ void ImapClient::onCredentialsStatusChanged()
+@@ -1837,4 +1837,20 @@ void ImapClient::onCredentialsStatusChanged()
      }
  }
  
-+void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
-+{
-+    if (list.contains(_config.id()) && !loggingIn()) {
-+        ImapConfiguration imapCfg1(_config);
-+        // copying here as the data is shared
-+        QMailAccountConfiguration config = QMailAccountConfiguration(_config.id());
-+        ImapConfiguration imapCfg2(config);
-+
-+        if (!imapCfg1.isValid()) {
-+            qMailLog(IMAP) << Q_FUNC_INFO << "current config is invalid";
-+            return;
-+        }
-+
-+        if (!imapCfg2.isValid()) {
-+            qMailLog(IMAP) << Q_FUNC_INFO << "invalid config from db";
-+            return;
-+        }
-+
-+        qMailLog(IMAP) << Q_FUNC_INFO << imapCfg1.mailUserName() ;
-+        // compare config modified by the User
-+        const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
-+                               (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-+                               (imapCfg1.mailServer() != imapCfg2.mailServer()) ||
-+                               (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
-+                               (imapCfg1.mailEncryption() != imapCfg2.mailEncryption()) ||
-+                               (imapCfg1.pushEnabled() != imapCfg2.pushEnabled());
-+        if (notEqual)
-+            closeIdleConnections();
-+
-+        if (imapCfg1.pushEnabled() != imapCfg2.pushEnabled()) {
-+            if (imapCfg2.pushEnabled())
-+                emit restartPushEmail();
-+        }
-+    }
-+}
-+
 +void ImapClient::closeIdleConnections()
 +{
 +    qMailLog(IMAP) << Q_FUNC_INFO << "Account was modified. Closing connections";
@@ -2191,7 +2145,7 @@ index 26ad7138..fb75e7c0 100644
 +
  #include "imapclient.moc"
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index c442f2f8..5e4f88f5 100644
+index c442f2f8..5d56e977 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -67,6 +67,7 @@ public:
@@ -2201,17 +2155,6 @@ index c442f2f8..5e4f88f5 100644
 +    void closeIdleConnections();
  
      ImapStrategyContext *strategyContext();
- 
-@@ -144,6 +145,10 @@ protected slots:
-     void messageBufferFlushed();
-     void onCredentialsStatusChanged();
- 
-+#ifdef USE_ACCOUNTS_QT
-+    void onAccountsUpdated(const QMailAccountIdList& list);
-+#endif
-+
- private:
-     friend class ImapStrategyContextBase;
  
 diff --git a/src/plugins/plugins.pro b/src/plugins/plugins.pro
 index 6c9464c2..a647ade7 100644

--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -92,13 +92,13 @@ base-qmf-oauth2-plugin/oauth2plugin.cpp
  src/libraries/qmfclient/share/email.service   |   65 +
  src/plugins/credentials/sso/plugin.cpp        |  123 +-
  src/plugins/credentials/sso/sso.pro           |    2 +-
- .../messageservices/imap/imapclient.cpp       |   39 +
- src/plugins/messageservices/imap/imapclient.h |    4 +
+ .../messageservices/imap/imapclient.cpp       |   55 +
+ src/plugins/messageservices/imap/imapclient.h |    5 +
  src/plugins/plugins.pro                       |    4 +
  src/tools/messageserver/servicehandler.cpp    |   13 +
  tests/tests.pri                               |    6 +
  tests/tst_qmailstore/tst_qmailstore.cpp       |   93 +-
- 14 files changed, 1640 insertions(+), 67 deletions(-)
+ 14 files changed, 1657 insertions(+), 67 deletions(-)
  create mode 100644 src/libraries/qmfclient/share/email.provider
  create mode 100644 src/libraries/qmfclient/share/email.service
 
@@ -2120,10 +2120,10 @@ index 9abae1c7..ac8c2902 100644
  HEADERS += plugin.h \
             ssomanager.h
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 4aaa48a1..bef0b027 100644
+index 26ad7138..fb75e7c0 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -438,6 +438,9 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
+@@ -473,6 +473,9 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
      connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
  
      setupAccount();
@@ -2133,7 +2133,7 @@ index 4aaa48a1..bef0b027 100644
  }
  
  ImapClient::~ImapClient()
-@@ -1807,4 +1810,56 @@ void ImapClient::onCredentialsStatusChanged()
+@@ -1837,4 +1840,56 @@ void ImapClient::onCredentialsStatusChanged()
      }
  }
  
@@ -2191,7 +2191,7 @@ index 4aaa48a1..bef0b027 100644
 +
  #include "imapclient.moc"
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index dbf5abec..64cb362f 100644
+index c442f2f8..5e4f88f5 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -67,6 +67,7 @@ public:
@@ -2202,7 +2202,7 @@ index dbf5abec..64cb362f 100644
  
      ImapStrategyContext *strategyContext();
  
-@@ -144,6 +144,10 @@ protected slots:
+@@ -144,6 +145,10 @@ protected slots:
      void messageBufferFlushed();
      void onCredentialsStatusChanged();
  

--- a/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
+++ b/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Use a specific retry delay for IMAP idle connections.
  2 files changed, 23 insertions(+), 11 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 64a1613a..91b27c17 100644
+index 29aae0f4..268a7e22 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -182,11 +182,12 @@ public:
@@ -56,7 +56,7 @@ index 64a1613a..91b27c17 100644
  }
  
  ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
-@@ -1748,20 +1760,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1752,20 +1764,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
                      this, SIGNAL(idleNewMailNotification(QMailFolderId)));
              connect(protocol, SIGNAL(idleFlagsChangedNotification(QMailFolderId)),
                      this, SIGNAL(idleFlagsChangedNotification(QMailFolderId)));

--- a/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
+++ b/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Use a specific retry delay for IMAP idle connections.
  2 files changed, 23 insertions(+), 11 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index bef0b027..344d2ab5 100644
+index fb75e7c0..a3714806 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -182,11 +182,12 @@ public:
@@ -26,7 +26,7 @@ index bef0b027..344d2ab5 100644
  
  protected slots:
      virtual void idleContinuation(ImapCommand, const QString &);
-@@ -202,6 +203,8 @@ protected:
+@@ -204,6 +205,8 @@ protected:
  private:
      QTimer _idleTimer; // Send a DONE command every 29 minutes
      QTimer _idleRecoveryTimer; // Check command hasn't hung
@@ -35,7 +35,7 @@ index bef0b027..344d2ab5 100644
      QMailCredentialsInterface *_credentials;
  };
  
-@@ -369,9 +372,18 @@ void IdleProtocol::idleErrorRecovery()
+@@ -404,9 +407,18 @@ void IdleProtocol::idleErrorRecovery()
      const int oneHour = 60*60;
      _idleRecoveryTimer.stop();
  
@@ -56,7 +56,7 @@ index bef0b027..344d2ab5 100644
  }
  
  ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
-@@ -1736,20 +1748,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1751,20 +1763,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
                      this, SIGNAL(idleNewMailNotification(QMailFolderId)));
              connect(protocol, SIGNAL(idleFlagsChangedNotification(QMailFolderId)),
                      this, SIGNAL(idleFlagsChangedNotification(QMailFolderId)));
@@ -85,10 +85,10 @@ index bef0b027..344d2ab5 100644
      }
      _protocol.close();
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 64cb362f..64b5fe8f 100644
+index 5e4f88f5..0b22075e 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -140,7 +140,7 @@ protected slots:
+@@ -141,7 +141,7 @@ protected slots:
      void checkCommandResponse(const ImapCommand, const OperationStatus);
      void commandTransition(const ImapCommand, const OperationStatus);
      void transportStatus(const QString& status);

--- a/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
+++ b/rpm/0003-Use-a-specific-retry-delay-for-IMAP-idle-connections.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Use a specific retry delay for IMAP idle connections.
  2 files changed, 23 insertions(+), 11 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index fb75e7c0..a3714806 100644
+index 64a1613a..91b27c17 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -182,11 +182,12 @@ public:
@@ -56,7 +56,7 @@ index fb75e7c0..a3714806 100644
  }
  
  ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
-@@ -1751,20 +1763,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1748,20 +1760,20 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
                      this, SIGNAL(idleNewMailNotification(QMailFolderId)));
              connect(protocol, SIGNAL(idleFlagsChangedNotification(QMailFolderId)),
                      this, SIGNAL(idleFlagsChangedNotification(QMailFolderId)));
@@ -85,7 +85,7 @@ index fb75e7c0..a3714806 100644
      }
      _protocol.close();
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 5e4f88f5..0b22075e 100644
+index 5d56e977..518047a9 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -141,7 +141,7 @@ protected slots:

--- a/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
+++ b/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] Don't save settings during IMAP logging in.
  5 files changed, 41 insertions(+), 12 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 344d2ab5..bafef831 100644
+index a3714806..d3e7ade5 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -1683,6 +1683,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
+@@ -1698,6 +1698,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
      folder->setStatus(QMailFolder::PartialContent, (count < folder->serverCount()));
  }
  
@@ -31,7 +31,7 @@ index 344d2ab5..bafef831 100644
  bool ImapClient::idlesEstablished()
  {
      ImapConfiguration imapCfg(_config);
-@@ -1772,7 +1781,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
+@@ -1787,7 +1796,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
          delete protocol;
      }
      _idlesEstablished = false;
@@ -41,10 +41,10 @@ index 344d2ab5..bafef831 100644
      emit restartPushEmail();
  }
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 64b5fe8f..8362043d 100644
+index 0b22075e..d1cecad5 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -83,6 +83,7 @@ public:
+@@ -84,6 +84,7 @@ public:
      QMailMessageKey trashKey(const QMailFolderId &folderId) const;
      QStringList deletedMessages(const QMailFolderId &folderId) const;
  

--- a/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
+++ b/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] Don't save settings during IMAP logging in.
  5 files changed, 41 insertions(+), 12 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 91b27c17..036c4bcd 100644
+index 268a7e22..da0bdbc3 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -1695,6 +1695,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
+@@ -1699,6 +1699,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
      folder->setStatus(QMailFolder::PartialContent, (count < folder->serverCount()));
  }
  
@@ -31,7 +31,7 @@ index 91b27c17..036c4bcd 100644
  bool ImapClient::idlesEstablished()
  {
      ImapConfiguration imapCfg(_config);
-@@ -1784,7 +1793,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
+@@ -1788,7 +1797,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
          delete protocol;
      }
      _idlesEstablished = false;
@@ -81,10 +81,10 @@ index 8f014828..70ccbd91 100644
  
      bool delimiterUnknown() const;
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 76c8e2a4..ac9e5033 100644
+index bef6d831..e6ac2bf4 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
-@@ -1564,6 +1564,10 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1558,6 +1558,10 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      bool isPushEnabled(imapCfg.pushEnabled());
      QStringList pushFolders(imapCfg.pushFolders());
      QString newConnectionSettings(connectionSettings(imapCfg));
@@ -95,7 +95,7 @@ index 76c8e2a4..ac9e5033 100644
      if (!isEnabled) {
          if (_accountWasEnabled) {
              // Account changed from enabled to disabled
-@@ -1574,18 +1578,27 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1568,18 +1572,27 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
          return;
      }
  

--- a/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
+++ b/rpm/0004-Don-t-save-settings-during-IMAP-logging-in.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] Don't save settings during IMAP logging in.
  5 files changed, 41 insertions(+), 12 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index a3714806..d3e7ade5 100644
+index 91b27c17..036c4bcd 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -1698,6 +1698,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
+@@ -1695,6 +1695,15 @@ void ImapClient::updateFolderCountStatus(QMailFolder *folder)
      folder->setStatus(QMailFolder::PartialContent, (count < folder->serverCount()));
  }
  
@@ -31,7 +31,7 @@ index a3714806..d3e7ade5 100644
  bool ImapClient::idlesEstablished()
  {
      ImapConfiguration imapCfg(_config);
-@@ -1787,7 +1796,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
+@@ -1784,7 +1793,7 @@ void ImapClient::idleOpenRequested(IdleProtocol *idleProtocol)
          delete protocol;
      }
      _idlesEstablished = false;
@@ -41,7 +41,7 @@ index a3714806..d3e7ade5 100644
      emit restartPushEmail();
  }
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 0b22075e..d1cecad5 100644
+index 518047a9..9330e033 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -84,6 +84,7 @@ public:

--- a/rpm/0006-Add-keepalive-timer-to-IMAP-IDLE-service.patch
+++ b/rpm/0006-Add-keepalive-timer-to-IMAP-IDLE-service.patch
@@ -27,7 +27,7 @@ index 4b65fc1e..03c19785 100644
             imapconfiguration.h \
             imapmailboxproperties.h \
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index ac9e5033..e98d498f 100644
+index e6ac2bf4..dd18e697 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1473,6 +1473,12 @@ ImapService::ImapService(const QMailAccountId &accountId)
@@ -41,9 +41,9 @@ index ac9e5033..e98d498f 100644
 +#endif
 +
      QMailAccount account(accountId);
-     if (!(account.status() & QMailAccount::CanSearchOnServer)) {
-         account.setStatus(QMailAccount::CanSearchOnServer, true);
-@@ -1879,7 +1885,24 @@ void ImapService::setPersistentConnectionStatus(bool status)
+     if (account.status() & QMailAccount::Enabled) {
+         enable();
+@@ -1873,7 +1879,24 @@ void ImapService::setPersistentConnectionStatus(bool status)
          }
      }
      _idling = status;

--- a/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -8,12 +8,12 @@ react to changes in the account schedule related to always-on mode
 and activate/deactivate IMAP IDLE.
 ---
  src/plugins/messageservices/imap/imap.pro     |   1 +
- .../messageservices/imap/imapclient.cpp       |  43 ++++++-
+ .../messageservices/imap/imapclient.cpp       |  32 ++++-
  src/plugins/messageservices/imap/imapclient.h |   3 +
  .../messageservices/imap/imapservice.cpp      | 110 +++++++++++++++---
  .../messageservices/imap/imapservice.h        |   4 +
  src/tools/systemd/messageserver5.service      |   2 +-
- 6 files changed, 143 insertions(+), 20 deletions(-)
+ 6 files changed, 132 insertions(+), 20 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
 index 03c19785..18608bae 100644
@@ -28,7 +28,7 @@ index 03c19785..18608bae 100644
  
  HEADERS += imapclient.h \
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index d3e7ade5..9359f1ad 100644
+index 036c4bcd..0f6294fe 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -432,6 +432,7 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
@@ -39,7 +39,7 @@ index d3e7ade5..9359f1ad 100644
        _credentials(QMailCredentialsFactory::getCredentialsHandlerForAccount(_config)),
        _loginFailed(false)
  {
-@@ -668,7 +669,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -665,7 +666,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
              }
  
              // We are now connected
@@ -47,7 +47,7 @@ index d3e7ade5..9359f1ad 100644
              _waitingForIdleFolderIds = configurationIdleFolderIds();
  
              if (!_idlesEstablished
-@@ -679,7 +679,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -676,7 +676,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                  emit updateStatus( tr("Logging in idle connection" ) );
                  monitor(_waitingForIdleFolderIds);
              } else {
@@ -56,7 +56,7 @@ index d3e7ade5..9359f1ad 100644
                      foreach(const QMailFolderId &id, _monitored.keys()) {
                          IdleProtocol *protocol = _monitored.take(id);
                          protocol->close();
-@@ -1709,8 +1709,7 @@ bool ImapClient::loggingIn() const
+@@ -1706,8 +1706,7 @@ bool ImapClient::loggingIn() const
  
  bool ImapClient::idlesEstablished()
  {
@@ -66,7 +66,7 @@ index d3e7ade5..9359f1ad 100644
          return true;
  
      return _idlesEstablished;
-@@ -1733,8 +1732,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
+@@ -1730,8 +1729,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
  {
      ImapConfiguration imapCfg(_config);            
      QMailFolderIdList folderIds;
@@ -77,7 +77,7 @@ index d3e7ade5..9359f1ad 100644
      foreach(QString folderName, imapCfg.pushFolders()) {
          QMailFolderId idleFolderId(mailboxId(folderName));
          if (idleFolderId.isValid()) {
-@@ -1750,7 +1750,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1747,7 +1747,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      
      ImapConfiguration imapCfg(_config);
      if (!_protocol.supportsCapability("IDLE")
@@ -86,7 +86,7 @@ index d3e7ade5..9359f1ad 100644
          return;
      }
      
-@@ -1826,6 +1826,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1823,6 +1823,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -113,40 +113,8 @@ index d3e7ade5..9359f1ad 100644
  void ImapClient::logIn()
  {
      emit updateStatus( tr("Logging in" ) );
-@@ -1880,6 +1900,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
-         }
- 
-         qMailLog(IMAP) << Q_FUNC_INFO << imapCfg1.mailUserName() ;
-+#ifdef USE_KEEPALIVE
-+        // compare config modified by the User
-+        const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
-+                               (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-+                               (imapCfg1.mailServer() != imapCfg2.mailServer()) ||
-+                               (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
-+                               (imapCfg1.mailEncryption() != imapCfg2.mailEncryption());
-+#else
-         // compare config modified by the User
-         const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
-                                (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-@@ -1887,13 +1915,16 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
-                                (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
-                                (imapCfg1.mailEncryption() != imapCfg2.mailEncryption()) ||
-                                (imapCfg1.pushEnabled() != imapCfg2.pushEnabled());
-+#endif
-         if (notEqual)
-             closeIdleConnections();
- 
-+#ifndef USE_KEEPALIVE
-         if (imapCfg1.pushEnabled() != imapCfg2.pushEnabled()) {
-             if (imapCfg2.pushEnabled())
-                 emit restartPushEmail();
-         }
-+#endif
-     }
- }
- 
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index d1cecad5..0bfa035d 100644
+index 9330e033..47615c57 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -94,6 +94,8 @@ public:
@@ -158,7 +126,7 @@ index d1cecad5..0bfa035d 100644
  
  signals:
      void errorOccurred(int, const QString &);
-@@ -187,6 +189,7 @@ private:
+@@ -183,6 +185,7 @@ private:
      QList<QMailMessageBufferFlushCallback*> callbacks;
      QVector<QMailMessage*> _bufferedMessages;
      int _pushConnectionsReserved;

--- a/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -28,7 +28,7 @@ index 03c19785..18608bae 100644
  
  HEADERS += imapclient.h \
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 036c4bcd..0f6294fe 100644
+index da0bdbc3..bcc1242b 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -432,6 +432,7 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
@@ -56,7 +56,7 @@ index 036c4bcd..0f6294fe 100644
                      foreach(const QMailFolderId &id, _monitored.keys()) {
                          IdleProtocol *protocol = _monitored.take(id);
                          protocol->close();
-@@ -1706,8 +1706,7 @@ bool ImapClient::loggingIn() const
+@@ -1710,8 +1710,7 @@ bool ImapClient::loggingIn() const
  
  bool ImapClient::idlesEstablished()
  {
@@ -66,7 +66,7 @@ index 036c4bcd..0f6294fe 100644
          return true;
  
      return _idlesEstablished;
-@@ -1730,8 +1729,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
+@@ -1734,8 +1733,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
  {
      ImapConfiguration imapCfg(_config);            
      QMailFolderIdList folderIds;
@@ -77,7 +77,7 @@ index 036c4bcd..0f6294fe 100644
      foreach(QString folderName, imapCfg.pushFolders()) {
          QMailFolderId idleFolderId(mailboxId(folderName));
          if (idleFolderId.isValid()) {
-@@ -1747,7 +1747,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1751,7 +1751,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      
      ImapConfiguration imapCfg(_config);
      if (!_protocol.supportsCapability("IDLE")
@@ -86,7 +86,7 @@ index 036c4bcd..0f6294fe 100644
          return;
      }
      
-@@ -1823,6 +1823,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1827,6 +1827,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -135,7 +135,7 @@ index 9330e033..47615c57 100644
      QMultiMap<QMailMessageId,QString> detachedTempFiles;
  
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index e98d498f..03fa2143 100644
+index dd18e697..7869b82d 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -46,6 +46,12 @@
@@ -162,9 +162,9 @@ index e98d498f..03fa2143 100644
 -#endif
 -
      QMailAccount account(accountId);
-     if (!(account.status() & QMailAccount::CanSearchOnServer)) {
-         account.setStatus(QMailAccount::CanSearchOnServer, true);
-@@ -1493,6 +1493,24 @@ ImapService::ImapService(const QMailAccountId &accountId)
+     if (account.status() & QMailAccount::Enabled) {
+         enable();
+@@ -1487,6 +1487,24 @@ ImapService::ImapService(const QMailAccountId &accountId)
      connect(QMailStore::instance(), SIGNAL(accountsUpdated(const QMailAccountIdList&)), 
              this, SLOT(accountsUpdated(const QMailAccountIdList&)));
      connect(_initiatePushEmailTimer, SIGNAL(timeout()), this, SLOT(initiatePushEmail()));
@@ -189,7 +189,7 @@ index e98d498f..03fa2143 100644
  }
  
  void ImapService::enable()
-@@ -1511,15 +1529,32 @@ void ImapService::enable()
+@@ -1505,15 +1523,32 @@ void ImapService::enable()
  
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
@@ -225,7 +225,7 @@ index e98d498f..03fa2143 100644
          if (!_initiatePushDelay.contains(_accountId)) {
              _initiatePushDelay.insert(_accountId, 0);
          } else if (_initiatePushDelay[_accountId] == 0) {
-@@ -1545,7 +1580,7 @@ void ImapService::disable()
+@@ -1539,7 +1574,7 @@ void ImapService::disable()
      _initiatePushEmailTimer->stop();
      setPersistentConnectionStatus(false);
      _accountWasEnabled = false;
@@ -234,7 +234,7 @@ index e98d498f..03fa2143 100644
      _previousPushFolders = imapCfg.pushFolders();
      _previousConnectionSettings = connectionSettings(imapCfg);
      _source->setIntervalTimer(0);
-@@ -1567,7 +1602,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1561,7 +1596,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
      bool isEnabled(account.status() & QMailAccount::Enabled);
@@ -243,7 +243,7 @@ index e98d498f..03fa2143 100644
      QStringList pushFolders(imapCfg.pushFolders());
      QString newConnectionSettings(connectionSettings(imapCfg));
      bool loggingIn = false;
-@@ -1602,7 +1637,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1596,7 +1631,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
          }
      } else {
          // Update the settings
@@ -252,7 +252,7 @@ index e98d498f..03fa2143 100644
          _previousPushFolders = imapCfg.pushFolders();
          _previousConnectionSettings = connectionSettings(imapCfg);
      }
-@@ -1678,6 +1713,12 @@ void ImapService::initiatePushEmail()
+@@ -1672,6 +1707,12 @@ void ImapService::initiatePushEmail()
  
      qMailLog(Messaging) << "Attempting to establish push email for account" << _accountId
                          << QMailAccount(_accountId).name();
@@ -265,7 +265,7 @@ index e98d498f..03fa2143 100644
      QMailFolderIdList ids(_client->configurationIdleFolderIds());
      if (ids.count()) {
          _establishingPushEmail = true;
-@@ -1730,6 +1771,18 @@ void ImapService::updateStatus(const QString &text)
+@@ -1724,6 +1765,18 @@ void ImapService::updateStatus(const QString &text)
      updateStatus(QMailServiceAction::Status::ErrNoError, text, _accountId);
  }
  
@@ -284,7 +284,7 @@ index e98d498f..03fa2143 100644
  void ImapService::createIdleSession()
  {
      // Fail after 10 sec if no network reply is received
-@@ -1865,9 +1918,15 @@ void ImapService::onSessionConnectionTimeout()
+@@ -1859,9 +1912,15 @@ void ImapService::onSessionConnectionTimeout()
  
  bool ImapService::accountPushEnabled()
  {
@@ -301,7 +301,7 @@ index e98d498f..03fa2143 100644
  }
  
  void ImapService::setPersistentConnectionStatus(bool status)
-@@ -1902,6 +1961,31 @@ void ImapService::startStopBackgroundActivity()
+@@ -1896,6 +1955,31 @@ void ImapService::startStopBackgroundActivity()
          _backgroundActivity->stop();
      }
  }

--- a/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0008-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -8,12 +8,12 @@ react to changes in the account schedule related to always-on mode
 and activate/deactivate IMAP IDLE.
 ---
  src/plugins/messageservices/imap/imap.pro     |   1 +
- .../messageservices/imap/imapclient.cpp       |  59 +++++++++-
- src/plugins/messageservices/imap/imapclient.h |   4 +
+ .../messageservices/imap/imapclient.cpp       |  43 ++++++-
+ src/plugins/messageservices/imap/imapclient.h |   3 +
  .../messageservices/imap/imapservice.cpp      | 110 +++++++++++++++---
  .../messageservices/imap/imapservice.h        |   4 +
  src/tools/systemd/messageserver5.service      |   2 +-
- 6 files changed, 160 insertions(+), 20 deletions(-)
+ 6 files changed, 143 insertions(+), 20 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imap.pro b/src/plugins/messageservices/imap/imap.pro
 index 03c19785..18608bae 100644
@@ -28,10 +28,10 @@ index 03c19785..18608bae 100644
  
  HEADERS += imapclient.h \
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index bafef831..e71325f2 100644
+index d3e7ade5..9359f1ad 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -397,6 +397,7 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
+@@ -432,6 +432,7 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
        _rapidClosing(false),
        _idleRetryDelay(InitialIdleRetryDelay),
        _pushConnectionsReserved(0),
@@ -39,7 +39,7 @@ index bafef831..e71325f2 100644
        _credentials(QMailCredentialsFactory::getCredentialsHandlerForAccount(_config)),
        _loginFailed(false)
  {
-@@ -633,7 +634,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -668,7 +669,6 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
              }
  
              // We are now connected
@@ -47,7 +47,7 @@ index bafef831..e71325f2 100644
              _waitingForIdleFolderIds = configurationIdleFolderIds();
  
              if (!_idlesEstablished
-@@ -644,7 +644,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
+@@ -679,7 +679,7 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                  emit updateStatus( tr("Logging in idle connection" ) );
                  monitor(_waitingForIdleFolderIds);
              } else {
@@ -56,7 +56,7 @@ index bafef831..e71325f2 100644
                      foreach(const QMailFolderId &id, _monitored.keys()) {
                          IdleProtocol *protocol = _monitored.take(id);
                          protocol->close();
-@@ -1694,8 +1694,7 @@ bool ImapClient::loggingIn() const
+@@ -1709,8 +1709,7 @@ bool ImapClient::loggingIn() const
  
  bool ImapClient::idlesEstablished()
  {
@@ -66,7 +66,7 @@ index bafef831..e71325f2 100644
          return true;
  
      return _idlesEstablished;
-@@ -1718,8 +1717,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
+@@ -1733,8 +1732,9 @@ QMailFolderIdList ImapClient::configurationIdleFolderIds()
  {
      ImapConfiguration imapCfg(_config);            
      QMailFolderIdList folderIds;
@@ -77,7 +77,7 @@ index bafef831..e71325f2 100644
      foreach(QString folderName, imapCfg.pushFolders()) {
          QMailFolderId idleFolderId(mailboxId(folderName));
          if (idleFolderId.isValid()) {
-@@ -1735,7 +1735,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1750,7 +1750,7 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      
      ImapConfiguration imapCfg(_config);
      if (!_protocol.supportsCapability("IDLE")
@@ -86,7 +86,7 @@ index bafef831..e71325f2 100644
          return;
      }
      
-@@ -1811,6 +1811,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
+@@ -1826,6 +1826,26 @@ void ImapClient::removeAllFromBuffer(QMailMessage *message)
      }
  }
  
@@ -110,10 +110,10 @@ index bafef831..e71325f2 100644
 +    }
 +}
 +
- void ImapClient::onCredentialsStatusChanged()
+ void ImapClient::logIn()
  {
-     qMailLog(IMAP)  << "Got credential status changed" << _credentials->status();
-@@ -1850,6 +1870,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+     emit updateStatus( tr("Logging in" ) );
+@@ -1880,6 +1900,14 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
          }
  
          qMailLog(IMAP) << Q_FUNC_INFO << imapCfg1.mailUserName() ;
@@ -128,7 +128,7 @@ index bafef831..e71325f2 100644
          // compare config modified by the User
          const bool& notEqual = (imapCfg1.mailUserName() != imapCfg2.mailUserName()) ||
                                 (imapCfg1.mailPassword() != imapCfg2.mailPassword()) ||
-@@ -1857,13 +1885,16 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
+@@ -1887,13 +1915,16 @@ void ImapClient::onAccountsUpdated(const QMailAccountIdList &list)
                                 (imapCfg1.mailPort() != imapCfg2.mailPort()) ||
                                 (imapCfg1.mailEncryption() != imapCfg2.mailEncryption()) ||
                                 (imapCfg1.pushEnabled() != imapCfg2.pushEnabled());
@@ -146,10 +146,10 @@ index bafef831..e71325f2 100644
  }
  
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 8362043d..e49f18e1 100644
+index d1cecad5..0bfa035d 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
-@@ -93,6 +94,8 @@ public:
+@@ -94,6 +94,8 @@ public:
      void setPushConnectionsReserved(int reserved) { _pushConnectionsReserved = reserved; }
      int idleRetryDelay() const { return _idleRetryDelay; }
      void setIdleRetryDelay(int delay) { _idleRetryDelay = delay; }
@@ -158,7 +158,7 @@ index 8362043d..e49f18e1 100644
  
  signals:
      void errorOccurred(int, const QString &);
-@@ -184,6 +187,7 @@ private:
+@@ -187,6 +189,7 @@ private:
      QList<QMailMessageBufferFlushCallback*> callbacks;
      QVector<QMailMessage*> _bufferedMessages;
      int _pushConnectionsReserved;

--- a/rpm/0009-Prevent-push-enabled-status-to-go-out-of-sync.patch
+++ b/rpm/0009-Prevent-push-enabled-status-to-go-out-of-sync.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Prevent push enabled status to go out of sync.
  1 file changed, 33 insertions(+), 24 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 03fa2143..c92a5f5d 100644
+index 7869b82d..b0bdb066 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -64,7 +64,10 @@ QString connectionSettings(ImapConfiguration &config)
@@ -32,9 +32,9 @@ index 03fa2143..c92a5f5d 100644
 +#endif
 +
      QMailAccount account(accountId);
-     if (!(account.status() & QMailAccount::CanSearchOnServer)) {
-         account.setStatus(QMailAccount::CanSearchOnServer, true);
-@@ -1501,8 +1509,6 @@ ImapService::ImapService(const QMailAccountId &accountId)
+     if (account.status() & QMailAccount::Enabled) {
+         enable();
+@@ -1495,8 +1503,6 @@ ImapService::ImapService(const QMailAccountId &accountId)
  
      // Connect to dbus signals emitted by buteo notifying schedule changes
      QDBusConnection m_dBusConnection(QDBusConnection::sessionBus());
@@ -43,7 +43,7 @@ index 03fa2143..c92a5f5d 100644
  
      if(!m_dBusConnection.isConnected()) {
          qWarning() << Q_FUNC_INFO << "Cannot connect to Dbus";
-@@ -1531,22 +1537,19 @@ void ImapService::enable()
+@@ -1525,22 +1531,19 @@ void ImapService::enable()
      ImapConfiguration imapCfg(accountCfg);
      bool pushEnabled = accountPushEnabled();
  #ifdef USE_KEEPALIVE
@@ -69,7 +69,7 @@ index 03fa2143..c92a5f5d 100644
      _previousPushFolders = imapCfg.pushFolders();
      _previousConnectionSettings = connectionSettings(imapCfg);
      
-@@ -1609,6 +1612,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
+@@ -1603,6 +1606,7 @@ void ImapService::accountsUpdated(const QMailAccountIdList &ids)
      if (_client) {
          loggingIn = _client->loggingIn();
      }
@@ -77,7 +77,7 @@ index 03fa2143..c92a5f5d 100644
      if (!isEnabled) {
          if (_accountWasEnabled) {
              // Account changed from enabled to disabled
-@@ -1716,7 +1720,7 @@ void ImapService::initiatePushEmail()
+@@ -1710,7 +1714,7 @@ void ImapService::initiatePushEmail()
  #ifdef USE_KEEPALIVE
      QMailAccountConfiguration accountCfg(_accountId);
      ImapConfiguration imapCfg(accountCfg);
@@ -86,7 +86,7 @@ index 03fa2143..c92a5f5d 100644
      _previousPushFolders = imapCfg.pushFolders();
  #endif
      QMailFolderIdList ids(_client->configurationIdleFolderIds());
-@@ -1966,23 +1970,28 @@ void ImapService::pushEnabledStatus(uint accountId, const QString &profileType,
+@@ -1960,23 +1964,28 @@ void ImapService::pushEnabledStatus(uint accountId, const QString &profileType,
  {
      qMailLog(Messaging) << "Received new idleState for account: " << accountId << "state: " << state << "profile type: " << profileType;
      if (accountId == _accountId.toULongLong() && profileType == QLatin1String("syncemail")) {

--- a/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0012-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -172,7 +172,7 @@ index e8563c39..3a41a1c1 100644
  #endif
  
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index c92a5f5d..26ba5610 100644
+index b0bdb066..44788de2 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -235,7 +235,7 @@ bool ImapService::Source::retrieveFolderList(const QMailAccountId &accountId, co

--- a/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
+++ b/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
@@ -15,10 +15,10 @@ code which caused the database change, otherwise crashes can result
  3 files changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index e71325f2..894feb08 100644
+index 9359f1ad..146f6358 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -452,7 +452,8 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
+@@ -487,7 +487,8 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
  
      setupAccount();
  #ifdef USE_ACCOUNTS_QT

--- a/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
+++ b/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
@@ -9,25 +9,10 @@ asynchronously to avoid deleting the socket out from underneath the
 code which caused the database change, otherwise crashes can result
 (specifically, in the ImapProtocol::incomingData method).
 ---
- src/plugins/messageservices/imap/imapclient.cpp  | 3 ++-
  src/plugins/messageservices/imap/imapservice.cpp | 2 +-
  src/plugins/messageservices/pop/popservice.cpp   | 2 +-
- 3 files changed, 4 insertions(+), 3 deletions(-)
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 9359f1ad..146f6358 100644
---- a/src/plugins/messageservices/imap/imapclient.cpp
-+++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -487,7 +487,8 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
- 
-     setupAccount();
- #ifdef USE_ACCOUNTS_QT
--    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)), this, SLOT(onAccountsUpdated(QMailAccountIdList)));
-+    connect(QMailStore::instance(), SIGNAL(accountsUpdated(QMailAccountIdList)),
-+            this, SLOT(onAccountsUpdated(QMailAccountIdList)), Qt::QueuedConnection);
- #endif
- }
- 
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
 index 26ba5610..be9bbd32 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp

--- a/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
+++ b/rpm/0015-Use-a-queued-connection-to-handle-accountsUpdated-si.patch
@@ -14,10 +14,10 @@ code which caused the database change, otherwise crashes can result
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index 26ba5610..be9bbd32 100644
+index 44788de2..1e9012ec 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
-@@ -1508,7 +1508,7 @@ ImapService::ImapService(const QMailAccountId &accountId)
+@@ -1502,7 +1502,7 @@ ImapService::ImapService(const QMailAccountId &accountId)
      }
      connect(_restartPushEmailTimer, SIGNAL(timeout()), this, SLOT(restartPushEmail()));
      connect(QMailStore::instance(), SIGNAL(accountsUpdated(const QMailAccountIdList&)), 

--- a/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0019-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -343,7 +343,7 @@ index 3c274119..0b18aaa5 100644
          transmissionInProgressIds = idSet;
          transmissionSetInitialized = true;
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index be9bbd32..215c4c00 100644
+index 1e9012ec..fef8fbf0 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1240,7 +1240,7 @@ bool ImapService::Source::prepareMessages(const QList<QPair<QMailMessagePart::Lo

--- a/rpm/0029-Revert-private-header-paths.patch
+++ b/rpm/0029-Revert-private-header-paths.patch
@@ -36,7 +36,7 @@ index c1404aab..ac9e9077 100644
  #include <QCoreApplication>
  #include <QList>
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 0f6294fe..27161d5e 100644
+index bcc1242b..0a310420 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -35,7 +35,7 @@

--- a/rpm/0029-Revert-private-header-paths.patch
+++ b/rpm/0029-Revert-private-header-paths.patch
@@ -36,7 +36,7 @@ index c1404aab..ac9e9077 100644
  #include <QCoreApplication>
  #include <QList>
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 1b7e642e..2b40f962 100644
+index 146f6358..e9a1fc56 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -35,7 +35,7 @@
@@ -75,7 +75,7 @@ index 4165a9bc..92dfc5e5 100644
  #include <qmaillog.h>
  #include <qmailaccount.h>
 diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index 32010a8e..5a69db4a 100644
+index 9255045f..78f51fea 100644
 --- a/src/plugins/messageservices/pop/popclient.cpp
 +++ b/src/plugins/messageservices/pop/popclient.cpp
 @@ -36,7 +36,7 @@

--- a/rpm/0029-Revert-private-header-paths.patch
+++ b/rpm/0029-Revert-private-header-paths.patch
@@ -36,7 +36,7 @@ index c1404aab..ac9e9077 100644
  #include <QCoreApplication>
  #include <QList>
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 146f6358..e9a1fc56 100644
+index 0f6294fe..27161d5e 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -35,7 +35,7 @@


### PR DESCRIPTION
IDLE is failing authentication after a fresh message server restart.