### PR TITLE
[messagingframework] Avoid crash if searching imap with invalid key. JB#45273

### DIFF
--- a/rpm/0016-Revert-Replace-deprecated-QString-SplitBehavior.patch
+++ b/rpm/0016-Revert-Replace-deprecated-QString-SplitBehavior.patch
@@ -79,7 +79,7 @@ index 9cf6fd3a..f5c6bf2d 100644
  
  void ImapConfiguration::setCapabilities(const QStringList &s)
 diff --git a/src/plugins/messageservices/imap/imapprotocol.cpp b/src/plugins/messageservices/imap/imapprotocol.cpp
-index 7063d1fa..d08b6f6f 100644
+index 6aa40fc9..d4e5f4d9 100644
 --- a/src/plugins/messageservices/imap/imapprotocol.cpp
 +++ b/src/plugins/messageservices/imap/imapprotocol.cpp
 @@ -409,10 +409,10 @@ void ImapState::untaggedResponse(ImapContext *c, const QString &line)


### PR DESCRIPTION
Sync with fix done upstream.