### PR TITLE
[messagingframework] Sync adjustments to protocolRequest API. JB#63343

### DIFF
--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -2228,7 +2228,7 @@ index 6c9464c2..a647ade7 100644
 +}
 +}
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index 89cfe5de..1c6da93b 100644
+index 474e4a73..73295774 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
 @@ -801,10 +801,23 @@ void ServiceHandler::accountsAdded(const QMailAccountIdList &ids)
@@ -2256,7 +2256,7 @@ index 89cfe5de..1c6da93b 100644
  
  void ServiceHandler::accountsRemoved(const QMailAccountIdList &ids)
 diff --git a/tests/tst_qmailstore/tst_qmailstore.cpp b/tests/tst_qmailstore/tst_qmailstore.cpp
-index c3e294e4..6a39450e 100644
+index fd370395..423abf00 100644
 --- a/tests/tst_qmailstore/tst_qmailstore.cpp
 +++ b/tests/tst_qmailstore/tst_qmailstore.cpp
 @@ -134,9 +134,9 @@ void tst_QMailStore::addAccount()

--- a/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -391,7 +391,7 @@ index 9eefa1ac..c37415f0 100644
          } else {
              completionList.clear();
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index 1c6da93b..446cc821 100644
+index 73295774..8a8792c6 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
 @@ -1004,11 +1004,6 @@ QSet<QMailMessageService*> ServiceHandler::sourceServiceSet(const QSet<QMailAcco
@@ -406,7 +406,7 @@ index 1c6da93b..446cc821 100644
  QSet<QMailMessageService*> ServiceHandler::sinkServiceSet(const QMailAccountId &id) const
  {
      QSet<QMailMessageService*> services;
-@@ -1264,10 +1259,10 @@ void ServiceHandler::expireAction()
+@@ -1268,10 +1263,10 @@ void ServiceHandler::expireAction()
                      }
  
                      if (retrievalSetModified) {
@@ -419,7 +419,7 @@ index 1c6da93b..446cc821 100644
                      }
  
                      mActiveActions.erase(it);
-@@ -1276,7 +1271,7 @@ void ServiceHandler::expireAction()
+@@ -1280,7 +1275,7 @@ void ServiceHandler::expireAction()
                  mActionExpiry.removeFirst();
  
                  // Restart the service(s) for each of these accounts
@@ -428,7 +428,7 @@ index 1c6da93b..446cc821 100644
                  deregisterAccountServices(ids, QMailServiceAction::Status::ErrTimeout, tr("Request is not progressing"));
                  registerAccountServices(ids);
  
-@@ -1341,10 +1336,10 @@ void ServiceHandler::cancelTransfer(quint64 action)
+@@ -1345,10 +1340,10 @@ void ServiceHandler::cancelTransfer(quint64 action)
          }
  
          if (retrievalSetModified) {
@@ -441,7 +441,7 @@ index 1c6da93b..446cc821 100644
          }
  
          //The ActionData might have already been deleted by actionCompleted, triggered by cancelOperation
-@@ -1392,7 +1387,7 @@ void ServiceHandler::transmitMessages(quint64 action, const QMailAccountId &acco
+@@ -1396,7 +1391,7 @@ void ServiceHandler::transmitMessages(quint64 action, const QMailAccountId &acco
              // Find the accounts that own these messages
              QMap<QMailAccountId, QList<QPair<QMailMessagePart::Location, QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
  
@@ -450,7 +450,7 @@ index 1c6da93b..446cc821 100644
  
              // Emit no signal after completing preparation
              enqueueRequest(action, serialize(unresolvedLists), sources, &ServiceHandler::dispatchPrepareMessages, 0, TransmitMessagesRequestType);
-@@ -1428,7 +1423,7 @@ void ServiceHandler::transmitMessage(quint64 action, const QMailMessageId &messa
+@@ -1432,7 +1427,7 @@ void ServiceHandler::transmitMessage(quint64 action, const QMailMessageId &messa
              // Find the accounts that own these messages
              QMap<QMailAccountId, QList<QPair<QMailMessagePart::Location, QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
  
@@ -459,7 +459,7 @@ index 1c6da93b..446cc821 100644
  
              // Emit no signal after completing preparation
              enqueueRequest(action, serialize(unresolvedLists), sources, &ServiceHandler::dispatchPrepareMessages, 0, TransmitMessagesRequestType);
-@@ -1725,7 +1720,7 @@ void ServiceHandler::retrieveMessages(quint64 action, const QMailMessageIdList &
+@@ -1729,7 +1724,7 @@ void ServiceHandler::retrieveMessages(quint64 action, const QMailMessageIdList &
  {
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
  
@@ -468,7 +468,7 @@ index 1c6da93b..446cc821 100644
      if (sources.isEmpty()) {
          reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to retrieve messages for unconfigured account"));
      } else {
-@@ -1762,7 +1757,7 @@ bool ServiceHandler::dispatchRetrieveMessages(quint64 action, const QByteArray &
+@@ -1766,7 +1761,7 @@ bool ServiceHandler::dispatchRetrieveMessages(quint64 action, const QByteArray &
          }
      }
  
@@ -477,7 +477,7 @@ index 1c6da93b..446cc821 100644
      return true;
  }
  
-@@ -1998,7 +1993,7 @@ void ServiceHandler::onlineDeleteMessages(quint64 action, const QMailMessageIdLi
+@@ -2002,7 +1997,7 @@ void ServiceHandler::onlineDeleteMessages(quint64 action, const QMailMessageIdLi
          discardMessages(action, messageIds);
      } else {
          QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -486,7 +486,7 @@ index 1c6da93b..446cc821 100644
          if (sources.isEmpty()) {
              reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to delete messages for unconfigured account"));
          } else {
-@@ -2154,7 +2149,7 @@ void ServiceHandler::onlineMoveMessages(quint64 action, const QMailMessageIdList
+@@ -2158,7 +2153,7 @@ void ServiceHandler::onlineMoveMessages(quint64 action, const QMailMessageIdList
      QSet<QMailMessageService*> sources;
  
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -495,7 +495,7 @@ index 1c6da93b..446cc821 100644
      if (sources.isEmpty()) {
          reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to move messages for unconfigured account"));
      } else {
-@@ -2195,7 +2190,7 @@ void ServiceHandler::onlineFlagMessagesAndMoveToStandardFolder(quint64 action, c
+@@ -2199,7 +2194,7 @@ void ServiceHandler::onlineFlagMessagesAndMoveToStandardFolder(quint64 action, c
      QSet<QMailMessageService*> sources;
  
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -504,7 +504,7 @@ index 1c6da93b..446cc821 100644
      if (sources.isEmpty()) {
          reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to flag messages for unconfigured account"));
      } else {
-@@ -2583,7 +2578,7 @@ void ServiceHandler::searchMessages(quint64 action, const QMailMessageKey& filte
+@@ -2587,7 +2582,7 @@ void ServiceHandler::searchMessages(quint64 action, const QMailMessageKey& filte
  {
      if (spec == QMailSearchAction::Remote) {
          // Find the accounts that we need to search within from the criteria
@@ -513,7 +513,7 @@ index 1c6da93b..446cc821 100644
  
          QSet<QMailMessageService*> sources(sourceServiceSet(searchAccountIds));
          if (sources.isEmpty()) {
-@@ -3171,7 +3166,7 @@ void ServiceHandler::setRetrievalInProgress(const QMailAccountId &accountId, boo
+@@ -3173,7 +3168,7 @@ void ServiceHandler::setRetrievalInProgress(const QMailAccountId &accountId, boo
      }
  
      if (modified) {
@@ -522,7 +522,7 @@ index 1c6da93b..446cc821 100644
      }
  }
  
-@@ -3188,7 +3183,7 @@ void ServiceHandler::setTransmissionInProgress(const QMailAccountId &accountId,
+@@ -3190,7 +3185,7 @@ void ServiceHandler::setTransmissionInProgress(const QMailAccountId &accountId,
      }
  
      if (modified) {
@@ -532,10 +532,10 @@ index 1c6da93b..446cc821 100644
  }
  
 diff --git a/src/tools/messageserver/servicehandler.h b/src/tools/messageserver/servicehandler.h
-index 5bfe48af..23d28ac4 100644
+index 90d95da2..53f85be2 100644
 --- a/src/tools/messageserver/servicehandler.h
 +++ b/src/tools/messageserver/servicehandler.h
-@@ -233,7 +233,6 @@ private:
+@@ -243,7 +243,6 @@ private:
  
      QSet<QMailMessageService*> sourceServiceSet(const QMailAccountId &id) const;
      QSet<QMailMessageService*> sourceServiceSet(const QSet<QMailAccountId> &ids) const;

--- a/rpm/0020-Revert-Fix-disappearance-of-QDateTime-QDate.patch
+++ b/rpm/0020-Revert-Fix-disappearance-of-QDateTime-QDate.patch
@@ -280,7 +280,7 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
-index 1ff42e03..0d9a37c1 100644
+index 1afd7817..f167c314 100644
 --- a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 +++ b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 @@ -342,8 +342,8 @@ void tst_QMailStorageAction::initTestCase()
@@ -372,7 +372,7 @@ index 1ff42e03..0d9a37c1 100644
      message.setStatus(QMailMessage::New, false);
      message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailstore/tst_qmailstore.cpp b/tests/tst_qmailstore/tst_qmailstore.cpp
-index 6a39450e..7501c35d 100644
+index 423abf00..9f065d36 100644
 --- a/tests/tst_qmailstore/tst_qmailstore.cpp
 +++ b/tests/tst_qmailstore/tst_qmailstore.cpp
 @@ -1778,8 +1778,8 @@ void tst_QMailStore::message()

--- a/rpm/0023-Fallback-to-sso-credential-plugin.patch
+++ b/rpm/0023-Fallback-to-sso-credential-plugin.patch
@@ -10,10 +10,10 @@ By default, if auth/plugin key is absent, the PlainCredentials are used
  1 file changed, 7 insertions(+), 8 deletions(-)
 
 diff --git a/src/libraries/qmfmessageserver/qmailcredentials.cpp b/src/libraries/qmfmessageserver/qmailcredentials.cpp
-index e0bdd6de..97e51340 100644
+index f929e695..43e41edb 100644
 --- a/src/libraries/qmfmessageserver/qmailcredentials.cpp
 +++ b/src/libraries/qmfmessageserver/qmailcredentials.cpp
-@@ -168,14 +168,13 @@ QMailCredentialsInterface *QMailCredentialsFactory::getCredentialsHandlerForAcco
+@@ -187,14 +187,13 @@ QMailCredentialsInterface *QMailCredentialsFactory::getCredentialsHandlerForAcco
      const QMailAccountConfiguration::ServiceConfiguration &auth = config.serviceConfiguration(QLatin1String("auth"));
      if (auth.id().isValid()) {
          const QString plugin = auth.value(QLatin1String("plugin"));

--- a/rpm/0024-Revert-private-header-paths.patch
+++ b/rpm/0024-Revert-private-header-paths.patch
@@ -74,7 +74,7 @@ index 6307a4d7..977278cf 100644
  #include <qmailmessagebuffer.h>
  #include <qmailtransport.h>
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index 446cc821..9e68d586 100644
+index 8a8792c6..f62c38a1 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
 @@ -33,7 +33,7 @@
@@ -165,7 +165,7 @@ index 338d7ea6..e206479f 100644
  
  
 diff --git a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
-index 0d9a37c1..005db7d1 100644
+index f167c314..46d402ad 100644
 --- a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 +++ b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 @@ -34,7 +34,7 @@
@@ -178,7 +178,7 @@ index 0d9a37c1..005db7d1 100644
  #include <qmaildisconnected.h>
  #include <qmailnamespace.h>
 diff --git a/tests/tst_qmailstore/tst_qmailstore.cpp b/tests/tst_qmailstore/tst_qmailstore.cpp
-index 7501c35d..ce937e71 100644
+index 9f065d36..9c28be89 100644
 --- a/tests/tst_qmailstore/tst_qmailstore.cpp
 +++ b/tests/tst_qmailstore/tst_qmailstore.cpp
 @@ -38,7 +38,7 @@

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -169,7 +169,6 @@ touch .git
 %qmake5 \
     QT_BUILD_PARTS+=tests \
     QMF_INSTALL_ROOT=%{_prefix} \
-    DEFINES+=QMF_ENABLE_LOGGING \
     DEFINES+=MESSAGESERVER_PLUGINS \
     DEFINES+=QMF_NO_MESSAGE_SERVICE_EDITOR \
     DEFINES+=QMF_NO_WIDGETS \
@@ -178,10 +177,9 @@ touch .git
     DEFINES+=USE_HTML_PARSER \
     CONFIG+=syslog
 
-make %{?_smp_mflags}
+%make_build
 
 %install
-rm -rf %{buildroot}
 %qmake5_install
 UNIT_DIR=%{buildroot}%{_userunitdir}/user-session.target.wants
 mkdir -p "$UNIT_DIR"
@@ -203,7 +201,6 @@ install -m 644 -p %{SOURCE2} %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 %postun -n libqmfclient1-qt5 -p /sbin/ldconfig
 
 %files devel
-%defattr(-,root,root,-)
 %{_includedir}/qt5/QmfClient
 %{_includedir}/qt5/QmfMessageServer
 %exclude %{_libdir}/cmake/Qt5QmfClient/Qt5QmfClient_.cmake
@@ -222,7 +219,6 @@ install -m 644 -p %{SOURCE2} %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 %{_datadir}/qt5/mkspecs/modules/qt_lib_qmfmessageserver_private.pri
 
 %files -n libqmfmessageserver1-qt5
-%defattr(-,root,root,-)
 %{_bindir}/messageserver5
 %{_bindir}/qmf-accountscheck
 %{_datadir}/mapplauncherd/privileges.d/*
@@ -233,7 +229,6 @@ install -m 644 -p %{SOURCE2} %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 %{_userunitdir}/user-session.target.wants/*.service
 
 %files -n libqmfclient1-qt5
-%defattr(-,root,root,-)
 %license LICENSE.LGPLv* LGPL_EXCEPTION.txt
 %{_libdir}/libQmfClient.so.*
 %{_libdir}/qt5/plugins/contentmanagers
@@ -243,7 +238,6 @@ install -m 644 -p %{SOURCE2} %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 
 %if 0
 %files tests
-%defattr(-,root,root,-)
 %{_datadir}/accounts/*
 /opt/tests/qmf-qt5
 %else


### PR DESCRIPTION
Changed protocolRequest API upstream to use QVariantMap instead of QVariant. Latter version got broken with D-Bus as IPC work.

Upstream also removed need to explicitly enable logging so the build option is removed here. Some small .spec cleanups while at it.

cc @dcaliste 