### PR TITLE
[messagingframework] Get setInResponseTo() from upstream.

### DIFF
--- a/rpm/0005-Use-Qt5-booster-to-save-memory.patch
+++ b/rpm/0005-Use-Qt5-booster-to-save-memory.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Use Qt5 booster to save memory.
  5 files changed, 16 insertions(+), 5 deletions(-)
 
 diff --git a/src/tools/messageserver/main.cpp b/src/tools/messageserver/main.cpp
-index 9f58c094..7da26def 100644
+index 77d26e1a..d1e74b7c 100644
 --- a/src/tools/messageserver/main.cpp
 +++ b/src/tools/messageserver/main.cpp
 @@ -40,7 +40,7 @@

--- a/rpm/0007-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
+++ b/rpm/0007-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
@@ -16,7 +16,7 @@ Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index 66cf59ad..c5d28051 100644
+index 70fb5c66..78ab1196 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
 @@ -1604,7 +1604,11 @@ namespace attachments

--- a/rpm/0013-Revert-Use-QRandomGenerator-instead-of-qrand.patch
+++ b/rpm/0013-Revert-Use-QRandomGenerator-instead-of-qrand.patch
@@ -11,7 +11,7 @@ This reverts commit 9c8962c1942eec471d495b3d11436087e7d46cdd.
  3 files changed, 31 insertions(+), 6 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index c5d28051..c5467b96 100644
+index 78ab1196..99a15b25 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
 @@ -50,7 +50,6 @@
@@ -22,7 +22,7 @@ index c5d28051..c5467b96 100644
  #include <QDataStream>
  #include <QTextStream>
  #include <QTextCodec>
-@@ -7947,6 +7946,25 @@ uint QMailMessagePrivate::indicativeSize() const
+@@ -7951,6 +7950,25 @@ uint QMailMessagePrivate::indicativeSize() const
      return (size + 1);
  }
  
@@ -48,7 +48,7 @@ index c5d28051..c5467b96 100644
  static QByteArray gBoundaryString;
  
  void QMF_EXPORT setQMailMessageBoundaryString(const QByteArray &boundary)
-@@ -7963,7 +7981,7 @@ static QByteArray boundaryString(const QByteArray &hash)
+@@ -7967,7 +7985,7 @@ static QByteArray boundaryString(const QByteArray &hash)
          return gBoundaryString;
  
      // Formulate a boundary that is very unlikely to clash with the content

--- a/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -378,10 +378,10 @@ index 3e1df7c8..ccf83689 100644
          if (foldersToSearch.isEmpty()) {
              ImapRetrieveFolderListStrategy::folderListCompleted(context);
 diff --git a/src/tools/messageserver/messageserver.cpp b/src/tools/messageserver/messageserver.cpp
-index ec0a3948..770d6e75 100644
+index 06a335ae..066b6413 100644
 --- a/src/tools/messageserver/messageserver.cpp
 +++ b/src/tools/messageserver/messageserver.cpp
-@@ -190,7 +190,7 @@ void MessageServer::retrievalCompleted(quint64 action)
+@@ -198,7 +198,7 @@ void MessageServer::retrievalCompleted(quint64 action)
          if (!completionAttempted) {
              // Complete the messages that we selected for immediate completion
              completionAttempted = true;

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git165
+Version:    4.0.4+git166
 Release:    1
 License:    (LGPLv2 or LGPLv3) with exception or Qt Commercial
 URL:        https://github.com/sailfishos/messagingframework


### PR DESCRIPTION
Add a convenient function in QMailMessage to
    properly compute the In-Reply-to: and References:
    headers when replying to a message.