### PR TITLE
[messagingframework] Upstream sync.

### DIFF
--- a/rpm/0002-Accounts-qt-integration.patch
+++ b/rpm/0002-Accounts-qt-integration.patch
@@ -198,10 +198,10 @@ index 6c9464c2..a647ade7 100644
 +}
 +}
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index 38e35ca0..f83e3e01 100644
+index 57696b73..f21f41c0 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
-@@ -804,10 +804,23 @@ void ServiceHandler::onAccountsAdded(const QMailAccountIdList &ids)
+@@ -702,10 +702,23 @@ void ServiceHandler::onAccountsAdded(const QMailAccountIdList &ids)
  
  void ServiceHandler::onAccountsUpdated(const QMailAccountIdList &ids)
  {

--- a/rpm/0004-Add-keepalive-timer-to-IMAP-IDLE-service.patch
+++ b/rpm/0004-Add-keepalive-timer-to-IMAP-IDLE-service.patch
@@ -28,10 +28,10 @@ index 9e92fe13..282358d3 100644
             imapconfiguration.h \
             imaplog.h \
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index 638a05a2..a8f691c1 100644
+index f8f00d04..53d25ecd 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
-@@ -449,9 +449,15 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
+@@ -448,9 +448,15 @@ ImapClient::ImapClient(const QMailAccountId &id, QObject* parent)
      connect(&_inactiveTimer, SIGNAL(timeout()),
              this, SLOT(connectionInactive()));
  
@@ -47,7 +47,7 @@ index 638a05a2..a8f691c1 100644
  
      connect(QMailMessageBuffer::instance(), SIGNAL(flushed()), this, SLOT(messageBufferFlushed()));
  
-@@ -1674,10 +1680,16 @@ bool ImapClient::isPushEmailEstablished()
+@@ -1672,10 +1678,16 @@ bool ImapClient::isPushEmailEstablished()
  
  void ImapClient::setIdlingForFolder(const QMailFolderId &id)
  {
@@ -64,7 +64,7 @@ index 638a05a2..a8f691c1 100644
      if (!_waitingForIdleFolderIds.isEmpty()) {
          _waitingForIdleFolderIds.removeOne(id);
          if (_waitingForIdleFolderIds.isEmpty()) {
-@@ -1707,7 +1719,11 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
+@@ -1705,7 +1717,11 @@ void ImapClient::monitor(const QMailFolderIdList &mailboxIds)
      static int count(0);
  
      if (mailboxIds.isEmpty()) {
@@ -75,9 +75,9 @@ index 638a05a2..a8f691c1 100644
 +#endif
      }
  
-     foreach(const QMailFolderId &id, _monitored.keys()) {
+     foreach (const QMailFolderId &id, _monitored.keys()) {
 diff --git a/src/plugins/messageservices/imap/imapclient.h b/src/plugins/messageservices/imap/imapclient.h
-index 8edc94b9..bb2e1354 100644
+index 82b92b37..edc215a5 100644
 --- a/src/plugins/messageservices/imap/imapclient.h
 +++ b/src/plugins/messageservices/imap/imapclient.h
 @@ -47,6 +47,9 @@

--- a/rpm/0005-Use-Qt5-booster-to-save-memory.patch
+++ b/rpm/0005-Use-Qt5-booster-to-save-memory.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Use Qt5 booster to save memory.
  5 files changed, 16 insertions(+), 5 deletions(-)
 
 diff --git a/src/tools/messageserver/main.cpp b/src/tools/messageserver/main.cpp
-index 77d26e1a..d1e74b7c 100644
+index 68426c6e..1c93d7b8 100644
 --- a/src/tools/messageserver/main.cpp
 +++ b/src/tools/messageserver/main.cpp
 @@ -40,7 +40,7 @@

--- a/rpm/0006-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
+++ b/rpm/0006-Listen-to-sync-schedule-changes-from-buteo-sync-fram.patch
@@ -27,7 +27,7 @@ index 282358d3..a479ebba 100644
  contains(DEFINES, USE_KEEPALIVE) {
      PKGCONFIG += keepalive
 diff --git a/src/plugins/messageservices/imap/imapconfiguration.cpp b/src/plugins/messageservices/imap/imapconfiguration.cpp
-index 3d839c69..7b516d4a 100644
+index 4192d1f0..b484b737 100644
 --- a/src/plugins/messageservices/imap/imapconfiguration.cpp
 +++ b/src/plugins/messageservices/imap/imapconfiguration.cpp
 @@ -103,7 +103,7 @@ QString ImapConfiguration::preferredTextSubtype() const
@@ -39,7 +39,7 @@ index 3d839c69..7b516d4a 100644
  }
  
  QString ImapConfiguration::baseFolder() const
-@@ -271,7 +271,7 @@ void ImapConfigurationEditor::setPreferredTextSubtype(const QString &str)
+@@ -267,7 +267,7 @@ void ImapConfigurationEditor::setPreferredTextSubtype(const QString &str)
  
  void ImapConfigurationEditor::setPushEnabled(bool b)
  {
@@ -49,7 +49,7 @@ index 3d839c69..7b516d4a 100644
  
  void ImapConfigurationEditor::setBaseFolder(const QString &s)
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index d7b7d1dd..d56e29b0 100644
+index d626e60e..a4859d7a 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -46,6 +46,10 @@
@@ -103,7 +103,7 @@ index d7b7d1dd..d56e29b0 100644
  {
  public:
 diff --git a/src/plugins/messageservices/imap/imapservice.h b/src/plugins/messageservices/imap/imapservice.h
-index 7b24794a..4cf549a5 100644
+index 5adb68a5..7795ed50 100644
 --- a/src/plugins/messageservices/imap/imapservice.h
 +++ b/src/plugins/messageservices/imap/imapservice.h
 @@ -75,6 +75,8 @@ protected slots:

--- a/rpm/0007-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
+++ b/rpm/0007-Use-EightBit-encoding-instead-of-Base64-for-text-typ.patch
@@ -16,14 +16,14 @@ Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index 29d1ac1c..3bb37f3d 100644
+index a8191669..8a8bde3d 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
-@@ -1604,7 +1604,11 @@ namespace attachments
+@@ -1555,7 +1555,11 @@ namespace attachments
                  disposition.setParameter("filename*", QMailMessageContentDisposition::encodeParameter(input, "UTF-8"));
              }
  
--            container->appendPart(QMailMessagePart::fromFile(filePath, disposition,attach_type, QMailMessageBody::Base64,
+-            container->appendPart(QMailMessagePart::fromFile(filePath, disposition, attach_type, QMailMessageBody::Base64,
 +            QMailMessageBody::TransferEncoding te(QMailMessageBody::Base64);
 +            if (attach_type.matches("text") || attach_type.matches("message", "rfc822"))
 +                te = QMailMessageBody::EightBit;

--- a/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -9,13 +9,13 @@ when downloading messages from different folders.
 Also captures the sync policy as part of the QMailAccount structure.
 ---
  src/libraries/qmfclient/libaccounts_p.cpp     | 40 +++++++++++++++++
- src/libraries/qmfclient/qmailaccount.cpp      | 10 +++++
+ src/libraries/qmfclient/qmailaccount.cpp      | 11 +++++
  src/libraries/qmfclient/qmailaccount.h        | 10 +++++
  .../messageservices/imap/imapservice.cpp      | 21 ++++++---
  .../messageservices/imap/imapstrategy.cpp     | 45 +++++++++++++++++--
  .../messageservices/imap/imapstrategy.h       |  7 +--
  .../messageservices/pop/popservice.cpp        |  7 +++
- 7 files changed, 128 insertions(+), 12 deletions(-)
+ 7 files changed, 129 insertions(+), 12 deletions(-)
 
 diff --git a/src/libraries/qmfclient/libaccounts_p.cpp b/src/libraries/qmfclient/libaccounts_p.cpp
 index 90e9cb1c..6a41c128 100644
@@ -90,7 +90,7 @@ index 90e9cb1c..6a41c128 100644
          sharedAccount->selectService(service);
          sharedAccount->setValue(QLatin1String("type"), static_cast<int>(account->messageType()));
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index 74117b8e..7792198d 100644
+index 492af585..7792198d 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
 @@ -86,6 +86,7 @@ public:
@@ -101,10 +101,11 @@ index 74117b8e..7792198d 100644
  
      QMap<QString, QString> _customFields;
      bool _customFieldsModified;
-@@ -732,3 +733,12 @@ void QMailAccount::addMessageSink(const QString &sink)
+@@ -731,3 +732,13 @@ void QMailAccount::addMessageSink(const QString &sink)
+ {
      d->_sinks.append(sink);
  }
- 
++
 +QMailAccount::FolderSyncPolicy QMailAccount::folderSyncPolicy() const
 +{
 +    return d->_folderSyncPolicy;
@@ -143,7 +144,7 @@ index 8b3333e6..15883b8d 100644
      void setStatus(quint64 newStatus);
      void setStatus(quint64 mask, bool set);
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index d56e29b0..c84b676c 100644
+index a4859d7a..21e21357 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -218,7 +218,7 @@ bool ImapService::Source::retrieveFolderList(const QMailAccountId &accountId, co
@@ -224,10 +225,10 @@ index d56e29b0..c84b676c 100644
      if (!_unavailable)
          return initiateStrategy();
 diff --git a/src/plugins/messageservices/imap/imapstrategy.cpp b/src/plugins/messageservices/imap/imapstrategy.cpp
-index af8a8018..3e1df7c8 100644
+index 66318e73..98214498 100644
 --- a/src/plugins/messageservices/imap/imapstrategy.cpp
 +++ b/src/plugins/messageservices/imap/imapstrategy.cpp
-@@ -2372,14 +2372,53 @@ void ImapSynchronizeBaseStrategy::previewDiscoveredMessages(ImapStrategyContextB
+@@ -2315,14 +2315,53 @@ void ImapSynchronizeBaseStrategy::previewDiscoveredMessages(ImapStrategyContextB
      }
  }
  
@@ -285,7 +286,7 @@ index af8a8018..3e1df7c8 100644
  
  bool ImapSynchronizeBaseStrategy::nextFolder()
 diff --git a/src/plugins/messageservices/imap/imapstrategy.h b/src/plugins/messageservices/imap/imapstrategy.h
-index 832a6883..25aac3c5 100644
+index b425d8db..5e12dcf8 100644
 --- a/src/plugins/messageservices/imap/imapstrategy.h
 +++ b/src/plugins/messageservices/imap/imapstrategy.h
 @@ -42,6 +42,7 @@

--- a/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
+++ b/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
@@ -87,7 +87,7 @@ index 15883b8d..e3b258d6 100644
      friend class QMailAccountPrivate;
      friend class QMailStore;
 diff --git a/src/plugins/messageservices/imap/imapconfiguration.cpp b/src/plugins/messageservices/imap/imapconfiguration.cpp
-index 7b516d4a..9e0b9ca0 100644
+index b484b737..810bfe75 100644
 --- a/src/plugins/messageservices/imap/imapconfiguration.cpp
 +++ b/src/plugins/messageservices/imap/imapconfiguration.cpp
 @@ -31,6 +31,8 @@

--- a/rpm/0011-Adjust-for-Qt-5.6.patch
+++ b/rpm/0011-Adjust-for-Qt-5.6.patch
@@ -32,19 +32,17 @@ index 6a41c128..a5fceeda 100644
              sharedAccount->setValue(QLatin1String("lastSynchronized"), quint64(0));
          }
 diff --git a/src/libraries/qmfmessageserver/qmailtransport.cpp b/src/libraries/qmfmessageserver/qmailtransport.cpp
-index aeb4645b..14812cd7 100644
+index 746fe48d..a2682105 100644
 --- a/src/libraries/qmfmessageserver/qmailtransport.cpp
 +++ b/src/libraries/qmfmessageserver/qmailtransport.cpp
-@@ -213,7 +213,7 @@ void QMailTransport::createSocket(EncryptType encryptType)
- #ifndef QT_NO_SSL
+@@ -189,13 +189,13 @@ void QMailTransport::createSocket(EncryptType encryptType)
+     mSocket = new Socket(this);
      encryption = encryptType;
      connect(mSocket, &QSslSocket::encrypted, this, &QMailTransport::encryptionEstablished);
 -    connect(mSocket, &QSslSocket::sslErrors, this, &QMailTransport::connectionFailed);
 +    connect(mSocket, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(connectionFailed(QList<QSslError>)));
- #else
-     Q_UNUSED(encryptType);
- #endif
-@@ -222,7 +222,7 @@ void QMailTransport::createSocket(EncryptType encryptType)
+ 
+     const int bufferLimit = 101*1024; // Limit memory used when downloading
      mSocket->setReadBufferSize( bufferLimit );
      mSocket->setObjectName(QString::fromUtf8(mName) + QString::fromLatin1("-socket"));
      connect(mSocket, &QAbstractSocket::connected, this, &QMailTransport::connectionEstablished);
@@ -54,10 +52,10 @@ index aeb4645b..14812cd7 100644
      connect(mSocket, &QAbstractSocket::bytesWritten, this, &QMailTransport::bytesWritten);
  
 diff --git a/tests/tst_smtp/tst_smtp.cpp b/tests/tst_smtp/tst_smtp.cpp
-index 8dcfbe3a..7defc685 100644
+index 99d534af..104393fa 100644
 --- a/tests/tst_smtp/tst_smtp.cpp
 +++ b/tests/tst_smtp/tst_smtp.cpp
-@@ -98,9 +98,9 @@ void tst_SmtpClient::test_connection()
+@@ -94,9 +94,9 @@ void tst_SmtpClient::test_connection()
      QVERIFY(completed.wait());
  
      QCOMPARE(updateStatus.count(), 3);
@@ -70,7 +68,7 @@ index 8dcfbe3a..7defc685 100644
  }
  
  void tst_SmtpClient::test_auth()
-@@ -119,9 +119,9 @@ void tst_SmtpClient::test_auth()
+@@ -115,9 +115,9 @@ void tst_SmtpClient::test_auth()
      QVERIFY(!completed.wait(250)); // Fails with wrong credentials
  
      QCOMPARE(updateStatus.count(), 3);
@@ -83,7 +81,7 @@ index 8dcfbe3a..7defc685 100644
  
      smtp.setSmtpAuthentication(QMail::PlainMechanism);
      QVERIFY(QMailStore::instance()->updateAccountConfiguration(&config));
-@@ -130,7 +130,7 @@ void tst_SmtpClient::test_auth()
+@@ -126,9 +126,9 @@ void tst_SmtpClient::test_auth()
      QVERIFY(!completed.wait(250)); // Fails with wrong credentials
  
      QCOMPARE(updateStatus.count(), 3);
@@ -94,3 +92,5 @@ index 8dcfbe3a..7defc685 100644
 +    QCOMPARE(updateStatus.takeFirst().first().toString(), QString::fromLatin1("Connected"));
 +    QCOMPARE(updateStatus.takeFirst().first().toString(), QString::fromLatin1("Connected"));
  }
+ 
+ QTEST_MAIN(tst_SmtpClient)

--- a/rpm/0013-Revert-Use-QRandomGenerator-instead-of-qrand.patch
+++ b/rpm/0013-Revert-Use-QRandomGenerator-instead-of-qrand.patch
@@ -11,7 +11,7 @@ This reverts commit 9c8962c1942eec471d495b3d11436087e7d46cdd.
  3 files changed, 31 insertions(+), 6 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessage.cpp b/src/libraries/qmfclient/qmailmessage.cpp
-index 3bb37f3d..0cdbd847 100644
+index 8a8bde3d..a5877cd9 100644
 --- a/src/libraries/qmfclient/qmailmessage.cpp
 +++ b/src/libraries/qmfclient/qmailmessage.cpp
 @@ -50,7 +50,6 @@
@@ -22,7 +22,7 @@ index 3bb37f3d..0cdbd847 100644
  #include <QDataStream>
  #include <QTextStream>
  #include <QTextCodec>
-@@ -7951,6 +7950,25 @@ uint QMailMessagePrivate::indicativeSize() const
+@@ -7833,6 +7832,25 @@ uint QMailMessagePrivate::indicativeSize() const
      return (size + 1);
  }
  
@@ -48,7 +48,7 @@ index 3bb37f3d..0cdbd847 100644
  static QByteArray gBoundaryString;
  
  void QMF_EXPORT setQMailMessageBoundaryString(const QByteArray &boundary)
-@@ -7967,7 +7985,7 @@ static QByteArray boundaryString(const QByteArray &hash)
+@@ -7849,7 +7867,7 @@ static QByteArray boundaryString(const QByteArray &hash)
          return gBoundaryString;
  
      // Formulate a boundary that is very unlikely to clash with the content
@@ -58,7 +58,7 @@ index 3bb37f3d..0cdbd847 100644
  
  template <typename F>
 diff --git a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
-index 055c55bd..e75a1223 100644
+index ab03d41b..b6b240dc 100644
 --- a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
 +++ b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
 @@ -42,7 +42,6 @@
@@ -79,7 +79,7 @@ index 055c55bd..e75a1223 100644
          if (r>57) r+=7;
          if (r>90) r+=6;
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index 9c913432..d234e949 100644
+index 545ba6a1..599a4e84 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
 @@ -43,7 +43,6 @@
@@ -88,9 +88,9 @@ index 9c913432..d234e949 100644
  #include <QNetworkInterface>
 -#include <QRandomGenerator>
  #include <QRegExp>
- #ifndef QT_NO_SSL
  #include <QSslSocket>
-@@ -60,9 +59,18 @@ Q_LOGGING_CATEGORY(lcSMTP, "org.qt.messageserver.smtp", QtWarningMsg)
+ 
+@@ -59,9 +58,18 @@ Q_LOGGING_CATEGORY(lcSMTP, "org.qt.messageserver.smtp", QtWarningMsg)
  // Only this many bytes is queued to be sent at a time.
  #define SENDING_BUFFER_SIZE 5000
  

--- a/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
+++ b/rpm/0014-Revert-Use-range-constructors-for-lists-and-sets.patch
@@ -6,20 +6,20 @@ Subject: [PATCH] Revert "Use range constructors for lists and sets"
 This reverts commit 260cb748a7556b1e6a70efa05522c01200dda823.
 ---
  src/libraries/qmfclient/qmailmessagekey.cpp   |  9 ++---
- .../qmfclient/qmailmessagelistmodel.cpp       |  4 +--
- src/libraries/qmfclient/qmailmessageset.cpp   | 15 ++++----
- .../qmfclient/qmailmessagethreadedmodel.cpp   | 14 +++-----
- src/libraries/qmfclient/qmailstore.cpp        | 15 +++-----
- .../qmfclient/qmailstorenotifier_p.cpp        | 18 +++++-----
+ .../qmfclient/qmailmessagelistmodel.cpp       |  4 +-
+ src/libraries/qmfclient/qmailmessageset.cpp   | 15 +++----
+ .../qmfclient/qmailmessagethreadedmodel.cpp   | 14 +++----
+ src/libraries/qmfclient/qmailstore.cpp        | 15 +++----
+ .../qmfclient/qmailstorenotifier_p.cpp        | 18 ++++-----
  .../messageservices/imap/imapservice.cpp      |  2 +-
- .../messageservices/imap/imapstrategy.cpp     | 24 ++++++-------
+ .../messageservices/imap/imapstrategy.cpp     | 24 +++++-------
  src/tools/messageserver/messageserver.cpp     |  2 +-
- src/tools/messageserver/servicehandler.cpp    | 35 ++++++++----------
+ src/tools/messageserver/servicehandler.cpp    | 39 +++++++------------
  src/tools/messageserver/servicehandler.h      |  1 -
  .../tst_qmaildisconnected.cpp                 |  2 +-
  .../tst_qmailserviceaction.cpp                |  2 +-
- .../tst_qmailstorekeys/tst_qmailstorekeys.cpp | 36 ++++++++-----------
- 14 files changed, 73 insertions(+), 106 deletions(-)
+ .../tst_qmailstorekeys/tst_qmailstorekeys.cpp | 36 +++++++----------
+ 14 files changed, 73 insertions(+), 110 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailmessagekey.cpp b/src/libraries/qmfclient/qmailmessagekey.cpp
 index 52428022..8ff85293 100644
@@ -56,7 +56,7 @@ index 52428022..8ff85293 100644
  #endif
  
 diff --git a/src/libraries/qmfclient/qmailmessagelistmodel.cpp b/src/libraries/qmfclient/qmailmessagelistmodel.cpp
-index 4d212a71..c00d633b 100644
+index e49bc71e..e5b69302 100644
 --- a/src/libraries/qmfclient/qmailmessagelistmodel.cpp
 +++ b/src/libraries/qmfclient/qmailmessagelistmodel.cpp
 @@ -403,9 +403,7 @@ bool QMailMessageListModelPrivate::updateMessages(const QMailMessageIdList &ids)
@@ -71,10 +71,10 @@ index 4d212a71..c00d633b 100644
      QMap<QMailMessageId, int> newPositions;
  
 diff --git a/src/libraries/qmfclient/qmailmessageset.cpp b/src/libraries/qmfclient/qmailmessageset.cpp
-index 05b366fa..09f276de 100644
+index d5dcb7d5..f5e57036 100644
 --- a/src/libraries/qmfclient/qmailmessageset.cpp
 +++ b/src/libraries/qmfclient/qmailmessageset.cpp
-@@ -958,7 +958,7 @@ void QMailFilterMessageSet::messagesAdded(const QMailMessageIdList &ids)
+@@ -956,7 +956,7 @@ void QMailFilterMessageSet::messagesAdded(const QMailMessageIdList &ids)
          QMailMessageIdList matchingIds = QMailStore::instance()->queryMessages(key & idFilter);
          if (!matchingIds.isEmpty()) {
              // Our filtered message set has changed
@@ -83,7 +83,7 @@ index 05b366fa..09f276de 100644
              update(this);
          }
      }
-@@ -969,7 +969,7 @@ void QMailFilterMessageSet::messagesRemoved(const QMailMessageIdList &ids)
+@@ -967,7 +967,7 @@ void QMailFilterMessageSet::messagesRemoved(const QMailMessageIdList &ids)
  {
      QSet<QMailMessageId>& _messageIds = impl(this)->_messageIds;
      if (!_messageIds.isEmpty()) {
@@ -92,7 +92,7 @@ index 05b366fa..09f276de 100644
  
          // See if any of these messages are in our set
          removedIds.intersect(_messageIds);
-@@ -986,12 +986,11 @@ void QMailFilterMessageSet::messagesUpdated(const QMailMessageIdList &ids)
+@@ -984,12 +984,11 @@ void QMailFilterMessageSet::messagesUpdated(const QMailMessageIdList &ids)
      QMailMessageKey key(messageKey());
      if (!key.isNonMatching()) {
          QSet<QMailMessageId>& _messageIds = impl(this)->_messageIds;
@@ -107,7 +107,7 @@ index 05b366fa..09f276de 100644
  
          QSet<QMailMessageId> presentIds = updatedIds;
          QSet<QMailMessageId> absentIds = updatedIds;
-@@ -1038,8 +1037,7 @@ void QMailFilterMessageSet::folderContentsModified(const QMailFolderIdList &)
+@@ -1036,8 +1035,7 @@ void QMailFilterMessageSet::folderContentsModified(const QMailFolderIdList &)
  void QMailFilterMessageSet::resyncState()
  {
      if (impl(this)->_minimized) {
@@ -117,7 +117,7 @@ index 05b366fa..09f276de 100644
      } else {
          impl(this)->_messageIds.clear();
      }
-@@ -1059,8 +1057,7 @@ void QMailFilterMessageSet::reset()
+@@ -1057,8 +1055,7 @@ void QMailFilterMessageSet::reset()
      if (impl(this)->_minimized) {
          disconnect(model(), SIGNAL(folderContentsModified(QMailFolderIdList)), this, SLOT(folderContentsModified(QMailFolderIdList)));
  
@@ -128,7 +128,7 @@ index 05b366fa..09f276de 100644
          connect(model(), SIGNAL(messagesAdded(QMailMessageIdList)), this, SLOT(messagesAdded(QMailMessageIdList)));
          connect(model(), SIGNAL(messagesRemoved(QMailMessageIdList)), this, SLOT(messagesRemoved(QMailMessageIdList)));
 diff --git a/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp b/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp
-index 352fced7..12ea9ea5 100644
+index 56d66079..4093fa25 100644
 --- a/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp
 +++ b/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp
 @@ -531,13 +531,12 @@ bool QMailMessageThreadedModelPrivate::processMessagesUpdated(const QMailMessage
@@ -170,7 +170,7 @@ index 352fced7..12ea9ea5 100644
  
      return true;
 diff --git a/src/libraries/qmfclient/qmailstore.cpp b/src/libraries/qmfclient/qmailstore.cpp
-index 26716ce6..1ba2bf14 100644
+index 6c217fc2..4f5f2a7e 100644
 --- a/src/libraries/qmfclient/qmailstore.cpp
 +++ b/src/libraries/qmfclient/qmailstore.cpp
 @@ -1236,8 +1236,7 @@ void QMailStore::emitAccountNotification(ChangeType type, const QMailAccountIdLi
@@ -309,7 +309,7 @@ index 162801bb..e8de2bef 100644
          transmissionInProgressIds = idSet;
          transmissionSetInitialized = true;
 diff --git a/src/plugins/messageservices/imap/imapservice.cpp b/src/plugins/messageservices/imap/imapservice.cpp
-index c84b676c..453dff2d 100644
+index 21e21357..87b14886 100644
 --- a/src/plugins/messageservices/imap/imapservice.cpp
 +++ b/src/plugins/messageservices/imap/imapservice.cpp
 @@ -1223,7 +1223,7 @@ bool ImapService::Source::prepareMessages(const QList<QPair<QMailMessagePart::Lo
@@ -322,10 +322,10 @@ index c84b676c..453dff2d 100644
  
          for (const QMailMessageMetaData &metaData : QMailStore::instance()->messagesMetaData(key, props)) {
 diff --git a/src/plugins/messageservices/imap/imapstrategy.cpp b/src/plugins/messageservices/imap/imapstrategy.cpp
-index 3e1df7c8..ccf83689 100644
+index 98214498..30626a1a 100644
 --- a/src/plugins/messageservices/imap/imapstrategy.cpp
 +++ b/src/plugins/messageservices/imap/imapstrategy.cpp
-@@ -349,15 +349,13 @@ QSet<QMailFolderId> foldersApplicableTo(QMailMessageKey const& messagekey, QSet<
+@@ -347,15 +347,13 @@ QSet<QMailFolderId> foldersApplicableTo(QMailMessageKey const& messagekey, QSet<
                      if (arg.op == QMailKey::Equal || arg.op == QMailKey::Includes) {
                          Q_ASSERT(arg.valueList.count() == 1);
                          Q_ASSERT(arg.valueList[0].canConvert<QMailFolderId>());
@@ -345,7 +345,7 @@ index 3e1df7c8..ccf83689 100644
                      } else {
                          Q_ASSERT(false);
                      }
-@@ -367,15 +365,13 @@ QSet<QMailFolderId> foldersApplicableTo(QMailMessageKey const& messagekey, QSet<
+@@ -365,15 +363,13 @@ QSet<QMailFolderId> foldersApplicableTo(QMailMessageKey const& messagekey, QSet<
                      if (arg.op == QMailKey::Equal || arg.op == QMailKey::Includes) {
                          Q_ASSERT(arg.valueList.count() == 1);
                          Q_ASSERT(arg.valueList[0].canConvert<QMailAccountId>());
@@ -365,7 +365,7 @@ index 3e1df7c8..ccf83689 100644
                      } else {
                          Q_ASSERT(false);
                      }
-@@ -1964,9 +1960,9 @@ void ImapSearchMessageStrategy::folderListCompleted(ImapStrategyContextBase *con
+@@ -1915,9 +1911,9 @@ void ImapSearchMessageStrategy::folderListCompleted(ImapStrategyContextBase *con
          _limit = -1;
          _count = false;
      } else {
@@ -378,7 +378,7 @@ index 3e1df7c8..ccf83689 100644
          if (foldersToSearch.isEmpty()) {
              ImapRetrieveFolderListStrategy::folderListCompleted(context);
 diff --git a/src/tools/messageserver/messageserver.cpp b/src/tools/messageserver/messageserver.cpp
-index 06a335ae..066b6413 100644
+index 75ed8a13..dcc81f35 100644
 --- a/src/tools/messageserver/messageserver.cpp
 +++ b/src/tools/messageserver/messageserver.cpp
 @@ -198,7 +198,7 @@ void MessageServer::retrievalCompleted(quint64 action)
@@ -391,10 +391,10 @@ index 06a335ae..066b6413 100644
          } else {
              completionList.clear();
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index f83e3e01..101ce93e 100644
+index f21f41c0..a268e3c9 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
-@@ -1017,11 +1017,6 @@ QSet<QMailMessageService*> ServiceHandler::sourceServiceSet(const QSet<QMailAcco
+@@ -919,11 +919,6 @@ QSet<QMailMessageService*> ServiceHandler::sourceServiceSet(const QSet<QMailAcco
      return services;
  }
  
@@ -406,20 +406,22 @@ index f83e3e01..101ce93e 100644
  QSet<QMailMessageService*> ServiceHandler::sinkServiceSet(const QMailAccountId &id) const
  {
      QSet<QMailMessageService*> services;
-@@ -1281,10 +1276,10 @@ void ServiceHandler::expireAction()
+@@ -1185,12 +1180,10 @@ void ServiceHandler::expireAction()
                      }
  
                      if (retrievalSetModified) {
--                        QMailStore::instance()->setRetrievalInProgress(QMailAccountIdList(_retrievalAccountIds.constBegin(), _retrievalAccountIds.constEnd()));
+-                        QMailStore::instance()->setRetrievalInProgress(QMailAccountIdList(_retrievalAccountIds.constBegin(),
+-                                                                                          _retrievalAccountIds.constEnd()));
 +                        QMailStore::instance()->setRetrievalInProgress(_retrievalAccountIds.toList());
                      }
                      if (transmissionSetModified) {
--                        QMailStore::instance()->setTransmissionInProgress(QMailAccountIdList(_transmissionAccountIds.constBegin(), _transmissionAccountIds.constEnd()));
+-                        QMailStore::instance()->setTransmissionInProgress(QMailAccountIdList(_transmissionAccountIds.constBegin(),
+-                                                                                             _transmissionAccountIds.constEnd()));
 +                        QMailStore::instance()->setTransmissionInProgress(_transmissionAccountIds.toList());
                      }
  
                      mActiveActions.erase(it);
-@@ -1293,7 +1288,7 @@ void ServiceHandler::expireAction()
+@@ -1199,7 +1192,7 @@ void ServiceHandler::expireAction()
                  mActionExpiry.removeFirst();
  
                  // Restart the service(s) for each of these accounts
@@ -428,47 +430,49 @@ index f83e3e01..101ce93e 100644
                  deregisterAccountServices(ids, QMailServiceAction::Status::ErrTimeout, tr("Request is not progressing"));
                  registerAccountServices(ids);
  
-@@ -1358,10 +1353,10 @@ void ServiceHandler::cancelTransfer(quint64 action)
+@@ -1264,12 +1257,10 @@ void ServiceHandler::cancelTransfer(quint64 action)
          }
  
          if (retrievalSetModified) {
--            QMailStore::instance()->setRetrievalInProgress(QMailAccountIdList(_retrievalAccountIds.constBegin(), _retrievalAccountIds.constEnd()));
+-            QMailStore::instance()->setRetrievalInProgress(QMailAccountIdList(_retrievalAccountIds.constBegin(),
+-                                                                              _retrievalAccountIds.constEnd()));
 +            QMailStore::instance()->setRetrievalInProgress(_retrievalAccountIds.toList());
          }
          if (transmissionSetModified) {
--            QMailStore::instance()->setTransmissionInProgress(QMailAccountIdList(_transmissionAccountIds.constBegin(), _transmissionAccountIds.constEnd()));
+-            QMailStore::instance()->setTransmissionInProgress(QMailAccountIdList(_transmissionAccountIds.constBegin(),
+-                                                                                 _transmissionAccountIds.constEnd()));
 +            QMailStore::instance()->setTransmissionInProgress(_transmissionAccountIds.toList());
          }
  
          //The ActionData might have already been deleted by actionCompleted, triggered by cancelOperation
-@@ -1409,7 +1404,7 @@ void ServiceHandler::transmitMessages(quint64 action, const QMailAccountId &acco
-             // Find the accounts that own these messages
-             QMap<QMailAccountId, QList<QPair<QMailMessagePart::Location, QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
+@@ -1345,7 +1336,7 @@ void ServiceHandler::transmitMessages(quint64 action, const QMailAccountId &acco
+                  QList<QPair<QMailMessagePart::Location,
+                              QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
  
 -            sources = sourceServiceSet(unresolvedLists.keys());
 +            sources = sourceServiceSet(unresolvedLists.keys().toSet());
  
              // Emit no signal after completing preparation
-             enqueueRequest(action, serialize(unresolvedLists), sources, &ServiceHandler::dispatchPrepareMessages, 0, TransmitMessagesRequestType);
-@@ -1445,7 +1440,7 @@ void ServiceHandler::transmitMessage(quint64 action, const QMailMessageId &messa
-             // Find the accounts that own these messages
-             QMap<QMailAccountId, QList<QPair<QMailMessagePart::Location, QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
+             enqueueRequest(new PrepareMessagesRequest(unresolvedLists), action, sources, &ServiceHandler::dispatchPrepareMessages, 0);
+@@ -1394,7 +1385,7 @@ void ServiceHandler::transmitMessage(quint64 action, const QMailMessageId &messa
+                  QList<QPair<QMailMessagePart::Location,
+                              QMailMessagePart::Location> > > unresolvedLists(messageResolvers(unresolvedMessages));
  
 -            sources = sourceServiceSet(unresolvedLists.keys());
 +            sources = sourceServiceSet(unresolvedLists.keys().toSet());
  
              // Emit no signal after completing preparation
-             enqueueRequest(action, serialize(unresolvedLists), sources, &ServiceHandler::dispatchPrepareMessages, 0, TransmitMessagesRequestType);
-@@ -1742,7 +1737,7 @@ void ServiceHandler::retrieveMessages(quint64 action, const QMailMessageIdList &
+             enqueueRequest(new PrepareMessagesRequest(unresolvedLists), action, sources, &ServiceHandler::dispatchPrepareMessages, 0);
+@@ -1769,7 +1760,7 @@ void ServiceHandler::retrieveMessages(quint64 action, const QMailMessageIdList &
  {
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
  
 -    QSet<QMailMessageService*> sources(sourceServiceSet(messageLists.keys()));
 +    QSet<QMailMessageService*> sources(sourceServiceSet(messageLists.keys().toSet()));
      if (sources.isEmpty()) {
-         reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to retrieve messages for unconfigured account"));
-     } else {
-@@ -1779,7 +1774,7 @@ bool ServiceHandler::dispatchRetrieveMessages(quint64 action, const QByteArray &
+         reportFailure(action, QMailServiceAction::Status::ErrNoConnection,
+                       tr("Unable to retrieve messages for unconfigured account"));
+@@ -1806,7 +1797,7 @@ bool ServiceHandler::dispatchRetrieveMessages(Request *req)
          }
      }
  
@@ -477,7 +481,7 @@ index f83e3e01..101ce93e 100644
      return true;
  }
  
-@@ -2015,7 +2010,7 @@ void ServiceHandler::onlineDeleteMessages(quint64 action, const QMailMessageIdLi
+@@ -2124,7 +2115,7 @@ void ServiceHandler::onlineDeleteMessages(quint64 action, const QMailMessageIdLi
          discardMessages(action, messageIds);
      } else {
          QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -486,7 +490,7 @@ index f83e3e01..101ce93e 100644
          if (sources.isEmpty()) {
              reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to delete messages for unconfigured account"));
          } else {
-@@ -2171,7 +2166,7 @@ void ServiceHandler::onlineMoveMessages(quint64 action, const QMailMessageIdList
+@@ -2319,7 +2310,7 @@ void ServiceHandler::onlineMoveMessages(quint64 action, const QMailMessageIdList
      QSet<QMailMessageService*> sources;
  
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -495,7 +499,7 @@ index f83e3e01..101ce93e 100644
      if (sources.isEmpty()) {
          reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to move messages for unconfigured account"));
      } else {
-@@ -2212,7 +2207,7 @@ void ServiceHandler::onlineFlagMessagesAndMoveToStandardFolder(quint64 action, c
+@@ -2374,7 +2365,7 @@ void ServiceHandler::onlineFlagMessagesAndMoveToStandardFolder(quint64 action, c
      QSet<QMailMessageService*> sources;
  
      QMap<QMailAccountId, QMailMessageIdList> messageLists(accountMessages(messageIds));
@@ -504,7 +508,7 @@ index f83e3e01..101ce93e 100644
      if (sources.isEmpty()) {
          reportFailure(action, QMailServiceAction::Status::ErrNoConnection, tr("Unable to flag messages for unconfigured account"));
      } else {
-@@ -2600,7 +2595,7 @@ void ServiceHandler::searchMessages(quint64 action, const QMailMessageKey& filte
+@@ -2821,7 +2812,7 @@ void ServiceHandler::searchMessages(quint64 action, const QMailMessageKey &filte
  {
      if (spec == QMailSearchAction::Remote) {
          // Find the accounts that we need to search within from the criteria
@@ -513,7 +517,7 @@ index f83e3e01..101ce93e 100644
  
          QSet<QMailMessageService*> sources(sourceServiceSet(searchAccountIds));
          if (sources.isEmpty()) {
-@@ -3186,7 +3181,7 @@ void ServiceHandler::setRetrievalInProgress(const QMailAccountId &accountId, boo
+@@ -3416,7 +3407,7 @@ void ServiceHandler::setRetrievalInProgress(const QMailAccountId &accountId, boo
      }
  
      if (modified) {
@@ -522,7 +526,7 @@ index f83e3e01..101ce93e 100644
      }
  }
  
-@@ -3203,7 +3198,7 @@ void ServiceHandler::setTransmissionInProgress(const QMailAccountId &accountId,
+@@ -3433,7 +3424,7 @@ void ServiceHandler::setTransmissionInProgress(const QMailAccountId &accountId,
      }
  
      if (modified) {
@@ -532,10 +536,10 @@ index f83e3e01..101ce93e 100644
  }
  
 diff --git a/src/tools/messageserver/servicehandler.h b/src/tools/messageserver/servicehandler.h
-index cf8c7c0a..ca2f7eae 100644
+index b95e42f1..9e26a4fb 100644
 --- a/src/tools/messageserver/servicehandler.h
 +++ b/src/tools/messageserver/servicehandler.h
-@@ -244,7 +244,6 @@ private:
+@@ -246,7 +246,6 @@ private:
  
      QSet<QMailMessageService*> sourceServiceSet(const QMailAccountId &id) const;
      QSet<QMailMessageService*> sourceServiceSet(const QSet<QMailAccountId> &ids) const;
@@ -544,10 +548,10 @@ index cf8c7c0a..ca2f7eae 100644
      QSet<QMailMessageService*> sinkServiceSet(const QMailAccountId &id) const;
      QSet<QMailMessageService*> sinkServiceSet(const QSet<QMailAccountId> &ids) const;
 diff --git a/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp b/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
-index a2641bc5..60a9369a 100644
+index bb08d638..f3467d6d 100644
 --- a/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
 +++ b/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
-@@ -411,7 +411,7 @@ void tst_QMailDisconnected::test_qmaildisconnected()
+@@ -406,7 +406,7 @@ void tst_QMailDisconnected::test_qmaildisconnected()
      QMailMessage dstMsg;
      QMailDisconnected::copyPreviousFolder(QMailMessage(savedMessage2), &dstMsg);
  
@@ -557,10 +561,10 @@ index a2641bc5..60a9369a 100644
      QMailDisconnected::copyToFolder(QMailMessageIdList() << inboxMessage1, archivedId1);
      QMailDisconnected::copyToStandardFolder(QMailMessageIdList() << inboxMessage1, QMailFolder::JunkFolder);
 diff --git a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
-index a0ae627b..bf598269 100644
+index bed5dafc..c9b73126 100644
 --- a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
 +++ b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
-@@ -412,7 +412,7 @@ void tst_QMailServiceAction::test_retrievalaction()
+@@ -408,7 +408,7 @@ void tst_QMailServiceAction::test_retrievalaction()
      uint min = 10240u;
      action.retrieveFolderList(accountId1, inboxId1);
      action.retrieveMessageList(accountId2, inboxId2);
@@ -570,7 +574,7 @@ index a0ae627b..bf598269 100644
  
      action.exportUpdates(accountId1);
 diff --git a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
-index af11b9f8..9120a4d2 100644
+index 68eeae44..f92689d8 100644
 --- a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
 +++ b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
 @@ -97,8 +97,7 @@ private:
@@ -603,7 +607,7 @@ index af11b9f8..9120a4d2 100644
      }
  
      QSet<QMailMessageId> messageSet() const
-@@ -573,9 +570,8 @@ void tst_QMailStoreKeys::accountId()
+@@ -569,9 +566,8 @@ void tst_QMailStoreKeys::accountId()
      QCOMPARE(accountSet(~QMailAccountKey::id(QMailAccountId(), NotEqual)), noAccounts);
  
      // List inclusion
@@ -615,7 +619,7 @@ index af11b9f8..9120a4d2 100644
      QCOMPARE(accountSet(QMailAccountKey::id(QMailAccountIdList() << accountId1)), accountSet() << accountId1);
      QCOMPARE(accountSet(~QMailAccountKey::id(QMailAccountIdList() << accountId1)), accountSet() << accountId2 << accountId3 << accountId4);
      QCOMPARE(accountSet(QMailAccountKey::id(QMailAccountIdList() << accountId2)), accountSet() << accountId2);
-@@ -584,8 +580,8 @@ void tst_QMailStoreKeys::accountId()
+@@ -580,8 +576,8 @@ void tst_QMailStoreKeys::accountId()
      QCOMPARE(accountSet(~QMailAccountKey::id(QMailAccountIdList() << accountId1 << accountId2)), accountSet() << accountId3 << accountId4);
  
      // List exclusion
@@ -626,7 +630,7 @@ index af11b9f8..9120a4d2 100644
      QCOMPARE(accountSet(QMailAccountKey::id(QMailAccountIdList() << accountId1, Excludes)), accountSet() << accountId2 << accountId3 << accountId4);
      QCOMPARE(accountSet(~QMailAccountKey::id(QMailAccountIdList() << accountId1, Excludes)), accountSet() << accountId1);
      QCOMPARE(accountSet(QMailAccountKey::id(QMailAccountIdList() << accountId2, Excludes)), accountSet() << accountId1 << accountId3 << accountId4);
-@@ -845,9 +841,8 @@ void tst_QMailStoreKeys::folderId()
+@@ -841,9 +837,8 @@ void tst_QMailStoreKeys::folderId()
      QCOMPARE(folderSet(~QMailFolderKey::id(QMailFolderId(), NotEqual)), noFolders);
  
      // List inclusion
@@ -638,7 +642,7 @@ index af11b9f8..9120a4d2 100644
      QCOMPARE(folderSet(QMailFolderKey::id(QMailFolderIdList() << inboxId1)), folderSet() << inboxId1);
      QCOMPARE(folderSet(~QMailFolderKey::id(QMailFolderIdList() << inboxId1)), standardFolders + folderSet() << savedId1 << archivedId1 << inboxId2 << savedId2 << archivedId2);
      QCOMPARE(folderSet(QMailFolderKey::id(QMailFolderIdList() << archivedId2)), folderSet() << archivedId2);
-@@ -856,8 +851,8 @@ void tst_QMailStoreKeys::folderId()
+@@ -852,8 +847,8 @@ void tst_QMailStoreKeys::folderId()
      QCOMPARE(folderSet(~QMailFolderKey::id(QMailFolderIdList() << inboxId1 << archivedId2)), standardFolders + folderSet() << savedId1 << archivedId1 << inboxId2 << savedId2);
  
      // List exclusion
@@ -649,7 +653,7 @@ index af11b9f8..9120a4d2 100644
      QCOMPARE(folderSet(QMailFolderKey::id(QMailFolderIdList() << inboxId1, Excludes)), standardFolders + folderSet() << savedId1 << archivedId1 << inboxId2 << savedId2 << archivedId2);
      QCOMPARE(folderSet(~QMailFolderKey::id(QMailFolderIdList() << inboxId1, Excludes)), folderSet() << inboxId1);
      QCOMPARE(folderSet(QMailFolderKey::id(QMailFolderIdList() << archivedId2, Excludes)), standardFolders + folderSet() << inboxId1 << savedId1 << archivedId1 << inboxId2 << savedId2);
-@@ -1327,9 +1322,8 @@ void tst_QMailStoreKeys::messageId()
+@@ -1323,9 +1318,8 @@ void tst_QMailStoreKeys::messageId()
      QCOMPARE(messageSet(~QMailMessageKey::id(QMailMessageId(), NotEqual)), noMessages);
  
      // List inclusion
@@ -661,7 +665,7 @@ index af11b9f8..9120a4d2 100644
      QCOMPARE(messageSet(QMailMessageKey::id(QMailMessageIdList() << smsMessage)), messageSet() << smsMessage);
      QCOMPARE(messageSet(~QMailMessageKey::id(QMailMessageIdList() << smsMessage)), allEmailMessages);
      QCOMPARE(messageSet(QMailMessageKey::id(QMailMessageIdList() << inboxMessage1)), messageSet() << inboxMessage1);
-@@ -1338,8 +1332,8 @@ void tst_QMailStoreKeys::messageId()
+@@ -1334,8 +1328,8 @@ void tst_QMailStoreKeys::messageId()
      QCOMPARE(messageSet(~QMailMessageKey::id(QMailMessageIdList() << smsMessage << inboxMessage1)), messageSet() << archivedMessage1 << inboxMessage2 << savedMessage2);
  
      // List Exclusion

--- a/rpm/0015-Revert-Adjust-to-Qt6-QMetaType-API-changes.patch
+++ b/rpm/0015-Revert-Adjust-to-Qt6-QMetaType-API-changes.patch
@@ -10,10 +10,10 @@ This reverts commit f53c2885bff3408bf6aa8d89a9cb913980f51e9b.
  2 files changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailstoresql_p.cpp b/src/libraries/qmfclient/qmailstoresql_p.cpp
-index 9e0c2291..d09c18bb 100644
+index d32b7bab..41b05b37 100644
 --- a/src/libraries/qmfclient/qmailstoresql_p.cpp
 +++ b/src/libraries/qmfclient/qmailstoresql_p.cpp
-@@ -2925,7 +2925,7 @@ static QString queryText(const QString &query, const QList<QVariant> &values)
+@@ -2915,7 +2915,7 @@ static QString queryText(const QString &query, const QList<QVariant> &values)
      int index = result.indexOf(marker);
      while ((index != -1) && (it != end)) {
          QString substitute((*it).toString());
@@ -22,7 +22,7 @@ index 9e0c2291..d09c18bb 100644
              substitute.prepend(quote).append(quote);
  
          result.replace(index, 1, substitute);
-@@ -2940,7 +2940,7 @@ static QString queryText(const QString &query, const QList<QVariant> &values)
+@@ -2930,7 +2930,7 @@ static QString queryText(const QString &query, const QList<QVariant> &values)
  static QString queryText(const QSqlQuery &query)
  {
      // Note: we currently only handle positional parameters
@@ -32,7 +32,7 @@ index 9e0c2291..d09c18bb 100644
  
  QSqlQuery QMailStoreSql::prepare(const QString& sql)
 diff --git a/src/libraries/qmfclient/support/qmailipc.h b/src/libraries/qmfclient/support/qmailipc.h
-index 3445263a..6713f6b4 100644
+index 58c5ccc4..925fdfbd 100644
 --- a/src/libraries/qmfclient/support/qmailipc.h
 +++ b/src/libraries/qmfclient/support/qmailipc.h
 @@ -58,9 +58,12 @@ struct QMetaTypeRegister

--- a/rpm/0016-Revert-Replace-deprecated-QString-SplitBehavior.patch
+++ b/rpm/0016-Revert-Replace-deprecated-QString-SplitBehavior.patch
@@ -14,7 +14,7 @@ This reverts commit faf30f7544c7a1f5ec07ac68d1f0b4fbf4ed855d.
  6 files changed, 15 insertions(+), 15 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailtimestamp.cpp b/src/libraries/qmfclient/qmailtimestamp.cpp
-index 214834f7..d022007e 100644
+index 2390cc8c..711ac4f4 100644
 --- a/src/libraries/qmfclient/qmailtimestamp.cpp
 +++ b/src/libraries/qmfclient/qmailtimestamp.cpp
 @@ -120,7 +120,7 @@ QMailTimeStampPrivate::QMailTimeStampPrivate(const QString& timeText)
@@ -27,7 +27,7 @@ index 214834f7..d022007e 100644
      int tokenCount = tokens.count();
      if ( tokenCount > 0 ) {
 diff --git a/src/libraries/qmfclient/support/qmailnamespace.cpp b/src/libraries/qmfclient/support/qmailnamespace.cpp
-index 4b392a2f..1f13ee34 100644
+index 5f0129c8..dd5482d9 100644
 --- a/src/libraries/qmfclient/support/qmailnamespace.cpp
 +++ b/src/libraries/qmfclient/support/qmailnamespace.cpp
 @@ -420,28 +420,28 @@ QMap<QByteArray, QStringList> standardFolderTranslations()
@@ -66,7 +66,7 @@ index 4b392a2f..1f13ee34 100644
          }
      }
 diff --git a/src/plugins/messageservices/imap/imapconfiguration.cpp b/src/plugins/messageservices/imap/imapconfiguration.cpp
-index 9e0b9ca0..3a292e2e 100644
+index 810bfe75..99b4fbeb 100644
 --- a/src/plugins/messageservices/imap/imapconfiguration.cpp
 +++ b/src/plugins/messageservices/imap/imapconfiguration.cpp
 @@ -145,7 +145,7 @@ bool ImapConfiguration::intervalCheckRoamingEnabled() const
@@ -79,10 +79,10 @@ index 9e0b9ca0..3a292e2e 100644
  
  void ImapConfiguration::setCapabilities(const QStringList &s)
 diff --git a/src/plugins/messageservices/imap/imapprotocol.cpp b/src/plugins/messageservices/imap/imapprotocol.cpp
-index 86fd69f2..e572a5a3 100644
+index d9cc74cd..cb932b3d 100644
 --- a/src/plugins/messageservices/imap/imapprotocol.cpp
 +++ b/src/plugins/messageservices/imap/imapprotocol.cpp
-@@ -409,10 +409,10 @@ void ImapState::untaggedResponse(ImapContext *c, const QString &line)
+@@ -405,10 +405,10 @@ void ImapState::untaggedResponse(ImapContext *c, const QString &line)
      } else if (line.indexOf("[CAPABILITY", 0) != -1) {
          int start = 0;
          QString temp = token(line, '[', ']', &start);
@@ -95,7 +95,7 @@ index 86fd69f2..e572a5a3 100644
          c->protocol()->setCapabilities(capabilities);
      }
  
-@@ -518,7 +518,7 @@ void CapabilityState::untaggedResponse(ImapContext *c, const QString &line)
+@@ -514,7 +514,7 @@ void CapabilityState::untaggedResponse(ImapContext *c, const QString &line)
  {
      QStringList capabilities;
      if (line.startsWith(QLatin1String("* CAPABILITY"))) {
@@ -104,7 +104,7 @@ index 86fd69f2..e572a5a3 100644
          c->protocol()->setCapabilities(capabilities);
      } else {
          ImapState::untaggedResponse(c, line);
-@@ -648,7 +648,7 @@ void LoginState::taggedResponse(ImapContext *c, const QString &line)
+@@ -640,7 +640,7 @@ void LoginState::taggedResponse(ImapContext *c, const QString &line)
      if (line.indexOf("[CAPABILITY", Qt::CaseInsensitive) != -1) {
          int start = 0;
          QString temp = token(line, '[', ']', &start);
@@ -113,7 +113,7 @@ index 86fd69f2..e572a5a3 100644
          c->protocol()->setCapabilities(capabilities);
      }
  
-@@ -1441,7 +1441,7 @@ void SelectedState::untaggedResponse(ImapContext *c, const QString &line)
+@@ -1432,7 +1432,7 @@ void SelectedState::untaggedResponse(ImapContext *c, const QString &line)
      } else if (line.indexOf("PERMANENTFLAGS", 0, Qt::CaseInsensitive) != -1) {
          int start = 0;
          QString temp = token(line, '(', ')', &start);
@@ -123,7 +123,7 @@ index 86fd69f2..e572a5a3 100644
          quint32 exists = c->exists();
          if (exists > 0) {
 diff --git a/src/plugins/messageservices/imap/integerregion.cpp b/src/plugins/messageservices/imap/integerregion.cpp
-index 763150b9..dbc0c54e 100644
+index 3daa98a4..fde4d0e8 100644
 --- a/src/plugins/messageservices/imap/integerregion.cpp
 +++ b/src/plugins/messageservices/imap/integerregion.cpp
 @@ -87,7 +87,7 @@ IntegerRegion::IntegerRegion(const QString &uidString)
@@ -132,14 +132,14 @@ index 763150b9..dbc0c54e 100644
      // TODO: sort uids in uidString if they are not already sorted
 -    QStringList rangeList = uidString.split(",", Qt::SkipEmptyParts);
 +    QStringList rangeList = uidString.split(",", QString::SkipEmptyParts);
-     foreach(const QString &s, rangeList) {
+     foreach (const QString &s, rangeList) {
          bool ok = false;
          int index = s.indexOf(":");
 diff --git a/src/plugins/messageservices/smtp/smtpclient.cpp b/src/plugins/messageservices/smtp/smtpclient.cpp
-index d234e949..f250d0f2 100644
+index 599a4e84..55378d36 100644
 --- a/src/plugins/messageservices/smtp/smtpclient.cpp
 +++ b/src/plugins/messageservices/smtp/smtpclient.cpp
-@@ -534,7 +534,7 @@ void SmtpClient::nextAction(const QString &response)
+@@ -529,7 +529,7 @@ void SmtpClient::nextAction(const QString &response)
                      QStringList authCaps;
                      foreach (QString const& capability, capabilities) {
                          if (capability.startsWith("AUTH", Qt::CaseInsensitive)) {

--- a/rpm/0018-Adjust-qmflist-for-missing-bits-in-5.6.patch
+++ b/rpm/0018-Adjust-qmflist-for-missing-bits-in-5.6.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Adjust qmflist for missing bits in 5.6
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmflist.h b/src/libraries/qmfclient/qmflist.h
-index e35b983e..6942f35e 100644
+index 17b5b7d9..00e53a93 100644
 --- a/src/libraries/qmfclient/qmflist.h
 +++ b/src/libraries/qmfclient/qmflist.h
 @@ -50,6 +50,8 @@

--- a/rpm/0019-Revert-loadRelax.patch
+++ b/rpm/0019-Revert-loadRelax.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Revert loadRelax()
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qprivateimplementation.h b/src/libraries/qmfclient/qprivateimplementation.h
-index 3f5e1daf..21c76d1b 100644
+index 076db456..504385f7 100644
 --- a/src/libraries/qmfclient/qprivateimplementation.h
 +++ b/src/libraries/qmfclient/qprivateimplementation.h
 @@ -99,7 +99,7 @@ public:

--- a/rpm/0020-Revert-Fix-disappearance-of-QDateTime-QDate.patch
+++ b/rpm/0020-Revert-Fix-disappearance-of-QDateTime-QDate.patch
@@ -18,10 +18,10 @@ This reverts commit a8db671f00ebf5aa56e57d1bdf1511d9af22c809.
  10 files changed, 92 insertions(+), 92 deletions(-)
 
 diff --git a/tests/tst_qmail_listmodels/tst_qmail_listmodels.cpp b/tests/tst_qmail_listmodels/tst_qmail_listmodels.cpp
-index 2ef9fb1c..a41b1789 100644
+index aaa4e1d0..75322222 100644
 --- a/tests/tst_qmail_listmodels/tst_qmail_listmodels.cpp
 +++ b/tests/tst_qmail_listmodels/tst_qmail_listmodels.cpp
-@@ -144,8 +144,8 @@ void tst_QMail_ListModels::initTestCase()
+@@ -139,8 +139,8 @@ void tst_QMail_ListModels::initTestCase()
      msg1.setFrom(QMailAddress("0404404040"));
      msg1.setTo(QMailAddress("0404040404"));
      msg1.setSubject("Where are you?");
@@ -32,7 +32,7 @@ index 2ef9fb1c..a41b1789 100644
      msg1.setStatus(QMailMessage::Incoming, true);
      msg1.setStatus(QMailMessage::New, false);
      msg1.setStatus(QMailMessage::Read, true);
-@@ -163,8 +163,8 @@ void tst_QMail_ListModels::initTestCase()
+@@ -158,8 +158,8 @@ void tst_QMail_ListModels::initTestCase()
      msg2.setTo(QMailAddress("old@example.org"));
      msg2.setCc(QMailAddressList() << QMailAddress("anotherguy@example.org"));
      msg2.setSubject("email message test");
@@ -44,10 +44,10 @@ index 2ef9fb1c..a41b1789 100644
      msg2.setStatus(QMailMessage::New, true);
      msg2.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmail_sortkeys/tst_qmail_sortkeys.cpp b/tests/tst_qmail_sortkeys/tst_qmail_sortkeys.cpp
-index 1266d68f..0761f315 100644
+index 7dd59785..42208d58 100644
 --- a/tests/tst_qmail_sortkeys/tst_qmail_sortkeys.cpp
 +++ b/tests/tst_qmail_sortkeys/tst_qmail_sortkeys.cpp
-@@ -265,8 +265,8 @@ void tst_QMail_SortKeys::initTestCase()
+@@ -261,8 +261,8 @@ void tst_QMail_SortKeys::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -58,7 +58,7 @@ index 1266d68f..0761f315 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -289,8 +289,8 @@ void tst_QMail_SortKeys::initTestCase()
+@@ -285,8 +285,8 @@ void tst_QMail_SortKeys::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -69,7 +69,7 @@ index 1266d68f..0761f315 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -313,8 +313,8 @@ void tst_QMail_SortKeys::initTestCase()
+@@ -309,8 +309,8 @@ void tst_QMail_SortKeys::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -80,7 +80,7 @@ index 1266d68f..0761f315 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -342,8 +342,8 @@ void tst_QMail_SortKeys::initTestCase()
+@@ -338,8 +338,8 @@ void tst_QMail_SortKeys::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -91,7 +91,7 @@ index 1266d68f..0761f315 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -369,8 +369,8 @@ void tst_QMail_SortKeys::initTestCase()
+@@ -365,8 +365,8 @@ void tst_QMail_SortKeys::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -103,10 +103,10 @@ index 1266d68f..0761f315 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp b/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
-index 60a9369a..bc6f10ed 100644
+index f3467d6d..28688772 100644
 --- a/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
 +++ b/tests/tst_qmaildisconnected/tst_qmaildisconnected.cpp
-@@ -265,8 +265,8 @@ void tst_QMailDisconnected::initTestCase()
+@@ -260,8 +260,8 @@ void tst_QMailDisconnected::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -117,7 +117,7 @@ index 60a9369a..bc6f10ed 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -289,8 +289,8 @@ void tst_QMailDisconnected::initTestCase()
+@@ -284,8 +284,8 @@ void tst_QMailDisconnected::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -128,7 +128,7 @@ index 60a9369a..bc6f10ed 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -313,8 +313,8 @@ void tst_QMailDisconnected::initTestCase()
+@@ -308,8 +308,8 @@ void tst_QMailDisconnected::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -139,7 +139,7 @@ index 60a9369a..bc6f10ed 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -342,8 +342,8 @@ void tst_QMailDisconnected::initTestCase()
+@@ -337,8 +337,8 @@ void tst_QMailDisconnected::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -150,7 +150,7 @@ index 60a9369a..bc6f10ed 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -369,8 +369,8 @@ void tst_QMailDisconnected::initTestCase()
+@@ -364,8 +364,8 @@ void tst_QMailDisconnected::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -162,10 +162,10 @@ index 60a9369a..bc6f10ed 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailmessageset/tst_qmailmessageset.cpp b/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
-index fe040695..7fc7083d 100644
+index ff0e029d..01d10c52 100644
 --- a/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
 +++ b/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
-@@ -271,8 +271,8 @@ void tst_QMailMessageSet::initTestCase()
+@@ -267,8 +267,8 @@ void tst_QMailMessageSet::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -176,7 +176,7 @@ index fe040695..7fc7083d 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -295,8 +295,8 @@ void tst_QMailMessageSet::initTestCase()
+@@ -291,8 +291,8 @@ void tst_QMailMessageSet::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -187,7 +187,7 @@ index fe040695..7fc7083d 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -319,8 +319,8 @@ void tst_QMailMessageSet::initTestCase()
+@@ -315,8 +315,8 @@ void tst_QMailMessageSet::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -198,7 +198,7 @@ index fe040695..7fc7083d 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -348,8 +348,8 @@ void tst_QMailMessageSet::initTestCase()
+@@ -344,8 +344,8 @@ void tst_QMailMessageSet::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -209,7 +209,7 @@ index fe040695..7fc7083d 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -375,8 +375,8 @@ void tst_QMailMessageSet::initTestCase()
+@@ -371,8 +371,8 @@ void tst_QMailMessageSet::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -221,10 +221,10 @@ index fe040695..7fc7083d 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
-index bf598269..338d7ea6 100644
+index c9b73126..0a0d2ceb 100644
 --- a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
 +++ b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
-@@ -269,8 +269,8 @@ void tst_QMailServiceAction::initTestCase()
+@@ -265,8 +265,8 @@ void tst_QMailServiceAction::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -235,7 +235,7 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -293,8 +293,8 @@ void tst_QMailServiceAction::initTestCase()
+@@ -289,8 +289,8 @@ void tst_QMailServiceAction::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -246,7 +246,7 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -317,8 +317,8 @@ void tst_QMailServiceAction::initTestCase()
+@@ -313,8 +313,8 @@ void tst_QMailServiceAction::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -257,7 +257,7 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -346,8 +346,8 @@ void tst_QMailServiceAction::initTestCase()
+@@ -342,8 +342,8 @@ void tst_QMailServiceAction::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -268,7 +268,7 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -373,8 +373,8 @@ void tst_QMailServiceAction::initTestCase()
+@@ -369,8 +369,8 @@ void tst_QMailServiceAction::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -280,10 +280,10 @@ index bf598269..338d7ea6 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
-index 513eddce..d6517662 100644
+index e90402e2..6f690e83 100644
 --- a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 +++ b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
-@@ -342,8 +342,8 @@ void tst_QMailStorageAction::initTestCase()
+@@ -338,8 +338,8 @@ void tst_QMailStorageAction::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -294,7 +294,7 @@ index 513eddce..d6517662 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -366,8 +366,8 @@ void tst_QMailStorageAction::initTestCase()
+@@ -362,8 +362,8 @@ void tst_QMailStorageAction::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -305,7 +305,7 @@ index 513eddce..d6517662 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -390,8 +390,8 @@ void tst_QMailStorageAction::initTestCase()
+@@ -386,8 +386,8 @@ void tst_QMailStorageAction::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -316,7 +316,7 @@ index 513eddce..d6517662 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -419,8 +419,8 @@ void tst_QMailStorageAction::initTestCase()
+@@ -415,8 +415,8 @@ void tst_QMailStorageAction::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -327,7 +327,7 @@ index 513eddce..d6517662 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -446,8 +446,8 @@ void tst_QMailStorageAction::initTestCase()
+@@ -442,8 +442,8 @@ void tst_QMailStorageAction::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -338,7 +338,7 @@ index 513eddce..d6517662 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
-@@ -491,8 +491,8 @@ void tst_QMailStorageAction::test_storageaction_add()
+@@ -487,8 +487,8 @@ void tst_QMailStorageAction::test_storageaction_add()
      message.setFrom(QMailAddress("wilma@example.net"));
      message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
      message.setSubject("Simple test message");
@@ -349,7 +349,7 @@ index 513eddce..d6517662 100644
      message.setStatus(QMailMessage::Incoming, true);
      message.setStatus(QMailMessage::New, false);
      message.setStatus(QMailMessage::Read, false);
-@@ -743,8 +743,8 @@ void tst_QMailStorageAction::test_storageaction_rollBackUpdates()
+@@ -739,8 +739,8 @@ void tst_QMailStorageAction::test_storageaction_rollBackUpdates()
      message.setFrom(QMailAddress("barney@example.net"));
      message.setTo(QMailAddressList() << QMailAddress("account3@example.org") << QMailAddress("testing@test"));
      message.setSubject("Rollback test message");
@@ -360,7 +360,7 @@ index 513eddce..d6517662 100644
      message.setStatus(QMailMessage::Incoming, true);
      message.setStatus(QMailMessage::New, false);
      message.setStatus(QMailMessage::Read, false);
-@@ -840,8 +840,8 @@ void tst_QMailStorageAction::test_storageaction_discardMessages()
+@@ -836,8 +836,8 @@ void tst_QMailStorageAction::test_storageaction_discardMessages()
      message.setFrom(QMailAddress("barney@example.net"));
      message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
      message.setSubject("Another test message");
@@ -372,10 +372,10 @@ index 513eddce..d6517662 100644
      message.setStatus(QMailMessage::New, false);
      message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailstore/tst_qmailstore.cpp b/tests/tst_qmailstore/tst_qmailstore.cpp
-index 279fc1bd..40fd3932 100644
+index 8d552ba7..deec061a 100644
 --- a/tests/tst_qmailstore/tst_qmailstore.cpp
 +++ b/tests/tst_qmailstore/tst_qmailstore.cpp
-@@ -1779,8 +1779,8 @@ void tst_QMailStore::message()
+@@ -1773,8 +1773,8 @@ void tst_QMailStore::message()
      msg2.setParentAccountId(account2.id());
      msg2.setParentFolderId(QMailFolder::LocalStorageFolderId);
      msg2.setSubject("email message test");
@@ -387,10 +387,10 @@ index 279fc1bd..40fd3932 100644
      msg2.setStatus(QMailMessage::New, true);
      msg2.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
-index 9120a4d2..e881df8a 100644
+index f92689d8..6648d2e5 100644
 --- a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
 +++ b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
-@@ -343,8 +343,8 @@ void tst_QMailStoreKeys::initTestCase()
+@@ -339,8 +339,8 @@ void tst_QMailStoreKeys::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -401,7 +401,7 @@ index 9120a4d2..e881df8a 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -367,8 +367,8 @@ void tst_QMailStoreKeys::initTestCase()
+@@ -363,8 +363,8 @@ void tst_QMailStoreKeys::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -412,7 +412,7 @@ index 9120a4d2..e881df8a 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -391,8 +391,8 @@ void tst_QMailStoreKeys::initTestCase()
+@@ -387,8 +387,8 @@ void tst_QMailStoreKeys::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -423,7 +423,7 @@ index 9120a4d2..e881df8a 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -420,8 +420,8 @@ void tst_QMailStoreKeys::initTestCase()
+@@ -416,8 +416,8 @@ void tst_QMailStoreKeys::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -434,7 +434,7 @@ index 9120a4d2..e881df8a 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -447,8 +447,8 @@ void tst_QMailStoreKeys::initTestCase()
+@@ -443,8 +443,8 @@ void tst_QMailStoreKeys::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -445,7 +445,7 @@ index 9120a4d2..e881df8a 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
-@@ -1631,7 +1631,7 @@ void tst_QMailStoreKeys::messageSubject()
+@@ -1627,7 +1627,7 @@ void tst_QMailStoreKeys::messageSubject()
  
  void tst_QMailStoreKeys::messageTimeStamp()
  {
@@ -454,7 +454,7 @@ index 9120a4d2..e881df8a 100644
      today = today.toUTC();
      yesterday = yesterday.toUTC();
      lastWeek = lastWeek.toUTC();
-@@ -1691,7 +1691,7 @@ void tst_QMailStoreKeys::messageTimeStamp()
+@@ -1687,7 +1687,7 @@ void tst_QMailStoreKeys::messageTimeStamp()
  
  void tst_QMailStoreKeys::messageReceptionTimeStamp()
  {
@@ -464,10 +464,10 @@ index 9120a4d2..e881df8a 100644
      yesterday = yesterday.toUTC();
      lastWeek = lastWeek.toUTC();
 diff --git a/tests/tst_qmailthread/tst_qmailthread.cpp b/tests/tst_qmailthread/tst_qmailthread.cpp
-index 936f9c85..f98ce44c 100644
+index 504257e0..e7b8104d 100644
 --- a/tests/tst_qmailthread/tst_qmailthread.cpp
 +++ b/tests/tst_qmailthread/tst_qmailthread.cpp
-@@ -289,8 +289,8 @@ void tst_qmailthread::initTestCase()
+@@ -284,8 +284,8 @@ void tst_qmailthread::initTestCase()
          message.setFrom(QMailAddress("0404404040"));
          message.setTo(QMailAddress("0404040404"));
          message.setSubject("Where are you?");
@@ -478,7 +478,7 @@ index 936f9c85..f98ce44c 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, true);
-@@ -313,8 +313,8 @@ void tst_qmailthread::initTestCase()
+@@ -308,8 +308,8 @@ void tst_qmailthread::initTestCase()
          message.setFrom(QMailAddress("account2@example.org"));
          message.setTo(QMailAddress("account1@example.org"));
          message.setSubject("inboxMessage1");
@@ -489,7 +489,7 @@ index 936f9c85..f98ce44c 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, false);
-@@ -337,8 +337,8 @@ void tst_qmailthread::initTestCase()
+@@ -332,8 +332,8 @@ void tst_qmailthread::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("fred@example.net"));
          message.setSubject("archivedMessage1");
@@ -500,7 +500,7 @@ index 936f9c85..f98ce44c 100644
          message.setStatus(QMailMessage::Outgoing, true);
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Sent, true);
-@@ -366,8 +366,8 @@ void tst_qmailthread::initTestCase()
+@@ -361,8 +361,8 @@ void tst_qmailthread::initTestCase()
          message.setFrom(QMailAddress("account1@example.org"));
          message.setTo(QMailAddress("account2@example.org"));
          message.setSubject("Fwd:inboxMessage2");
@@ -511,7 +511,7 @@ index 936f9c85..f98ce44c 100644
          message.setStatus(QMailMessage::Incoming, true);
          message.setStatus(QMailMessage::New, true);
          message.setStatus(QMailMessage::Read, true);
-@@ -393,8 +393,8 @@ void tst_qmailthread::initTestCase()
+@@ -388,8 +388,8 @@ void tst_qmailthread::initTestCase()
          message.setFrom(QMailAddress("fred@example.net"));
          message.setTo(QMailAddressList() << QMailAddress("account2@example.org") << QMailAddress("testing@test"));
          message.setSubject("Re:savedMessage2");
@@ -523,10 +523,10 @@ index 936f9c85..f98ce44c 100644
          message.setStatus(QMailMessage::New, false);
          message.setStatus(QMailMessage::Read, false);
 diff --git a/tests/tst_storagemanager/tst_storagemanager.cpp b/tests/tst_storagemanager/tst_storagemanager.cpp
-index 6247f02a..1d5ea7cf 100644
+index 8724db84..3b4ea8dd 100644
 --- a/tests/tst_storagemanager/tst_storagemanager.cpp
 +++ b/tests/tst_storagemanager/tst_storagemanager.cpp
-@@ -157,8 +157,8 @@ void tst_StorageManager::initTestCase()
+@@ -154,8 +154,8 @@ void tst_StorageManager::initTestCase()
      msg1.setFrom(QMailAddress("0404404040"));
      msg1.setTo(QMailAddress("0404040404"));
      msg1.setSubject("Where are you?");
@@ -537,7 +537,7 @@ index 6247f02a..1d5ea7cf 100644
      msg1.setStatus(QMailMessage::Incoming, true);
      msg1.setStatus(QMailMessage::New, false);
      msg1.setStatus(QMailMessage::Read, true);
-@@ -176,8 +176,8 @@ void tst_StorageManager::initTestCase()
+@@ -173,8 +173,8 @@ void tst_StorageManager::initTestCase()
      msg2.setTo(QMailAddress("old@example.org"));
      msg2.setCc(QMailAddressList() << QMailAddress("anotherguy@example.org"));
      msg2.setSubject("email message test");
@@ -548,7 +548,7 @@ index 6247f02a..1d5ea7cf 100644
      msg2.setStatus(QMailMessage::Incoming, true);
      msg2.setStatus(QMailMessage::New, true);
      msg2.setStatus(QMailMessage::Read, false);
-@@ -216,8 +216,8 @@ void tst_StorageManager::test_add()
+@@ -213,8 +213,8 @@ void tst_StorageManager::test_add()
      msg3.setTo(QMailAddress("old@example.org"));
      msg3.setCc(QMailAddressList() << QMailAddress("anotherguy@example.org"));
      msg3.setSubject("email message test");
@@ -559,7 +559,7 @@ index 6247f02a..1d5ea7cf 100644
      msg3.setStatus(QMailMessage::Incoming, true);
      msg3.setStatus(QMailMessage::New, true);
      msg3.setStatus(QMailMessage::Read, false);
-@@ -240,8 +240,8 @@ void tst_StorageManager::test_remove()
+@@ -237,8 +237,8 @@ void tst_StorageManager::test_remove()
      msg4.setTo(QMailAddress("old@example.org"));
      msg4.setCc(QMailAddressList() << QMailAddress("anotherguy@example.org"));
      msg4.setSubject("email message test");

--- a/rpm/0023-Fallback-to-sso-credential-plugin.patch
+++ b/rpm/0023-Fallback-to-sso-credential-plugin.patch
@@ -10,7 +10,7 @@ By default, if auth/plugin key is absent, the PlainCredentials are used
  1 file changed, 7 insertions(+), 8 deletions(-)
 
 diff --git a/src/libraries/qmfmessageserver/qmailcredentials.cpp b/src/libraries/qmfmessageserver/qmailcredentials.cpp
-index 9e05a918..1bcd98e7 100644
+index 8e324cc5..b0bd01b3 100644
 --- a/src/libraries/qmfmessageserver/qmailcredentials.cpp
 +++ b/src/libraries/qmfmessageserver/qmailcredentials.cpp
 @@ -187,14 +187,13 @@ QMailCredentialsInterface *QMailCredentialsFactory::getCredentialsHandlerForAcco

--- a/rpm/0024-Revert-private-header-paths.patch
+++ b/rpm/0024-Revert-private-header-paths.patch
@@ -22,7 +22,7 @@ Subject: [PATCH] Revert private header paths
  15 files changed, 15 insertions(+), 15 deletions(-)
 
 diff --git a/src/plugins/messageservices/imap/imapclient.cpp b/src/plugins/messageservices/imap/imapclient.cpp
-index a8f691c1..5c807374 100644
+index 53d25ecd..47a7e3d2 100644
 --- a/src/plugins/messageservices/imap/imapclient.cpp
 +++ b/src/plugins/messageservices/imap/imapclient.cpp
 @@ -36,7 +36,7 @@
@@ -48,7 +48,7 @@ index 3002ffe8..c5c01d1c 100644
  #include <qmailtransport.h>
  #include <qmailcredentials.h>
 diff --git a/src/plugins/messageservices/imap/imapstrategy.cpp b/src/plugins/messageservices/imap/imapstrategy.cpp
-index ccf83689..e42635b6 100644
+index 30626a1a..4421d0a7 100644
 --- a/src/plugins/messageservices/imap/imapstrategy.cpp
 +++ b/src/plugins/messageservices/imap/imapstrategy.cpp
 @@ -35,7 +35,7 @@
@@ -61,7 +61,7 @@ index ccf83689..e42635b6 100644
  #include <qmailaccount.h>
  #include <qmailcrypto.h>
 diff --git a/src/plugins/messageservices/pop/popclient.cpp b/src/plugins/messageservices/pop/popclient.cpp
-index 3b6947de..4ea5c2dc 100644
+index 444965bd..3f3cd540 100644
 --- a/src/plugins/messageservices/pop/popclient.cpp
 +++ b/src/plugins/messageservices/pop/popclient.cpp
 @@ -37,7 +37,7 @@
@@ -74,7 +74,7 @@ index 3b6947de..4ea5c2dc 100644
  #include <qmailmessagebuffer.h>
  #include <qmailtransport.h>
 diff --git a/src/tools/messageserver/servicehandler.cpp b/src/tools/messageserver/servicehandler.cpp
-index 101ce93e..a91f98ac 100644
+index a268e3c9..a5249900 100644
 --- a/src/tools/messageserver/servicehandler.cpp
 +++ b/src/tools/messageserver/servicehandler.cpp
 @@ -33,7 +33,7 @@
@@ -87,7 +87,7 @@ index 101ce93e..a91f98ac 100644
  #include <qmailmessageserver.h>
  #include <qmailserviceconfiguration.h>
 diff --git a/tests/tst_locks/tst_locks.cpp b/tests/tst_locks/tst_locks.cpp
-index 76430bfa..dc1b7902 100644
+index 423b4657..61cca92c 100644
 --- a/tests/tst_locks/tst_locks.cpp
 +++ b/tests/tst_locks/tst_locks.cpp
 @@ -34,7 +34,7 @@
@@ -113,7 +113,7 @@ index 0e37852a..0d29c28f 100644
  /*
      This class primarily tests that LongStream class correctly stores messages.
 diff --git a/tests/tst_longstring/tst_longstring.cpp b/tests/tst_longstring/tst_longstring.cpp
-index ba05242e..282172c3 100644
+index 76be3b77..1f2e65cf 100644
 --- a/tests/tst_longstring/tst_longstring.cpp
 +++ b/tests/tst_longstring/tst_longstring.cpp
 @@ -34,7 +34,7 @@
@@ -126,7 +126,7 @@ index ba05242e..282172c3 100644
  
  
 diff --git a/tests/tst_python_email/tst_python_email.cpp b/tests/tst_python_email/tst_python_email.cpp
-index 619fd7d6..becaac81 100644
+index b539983f..fe34af80 100644
 --- a/tests/tst_python_email/tst_python_email.cpp
 +++ b/tests/tst_python_email/tst_python_email.cpp
 @@ -36,7 +36,7 @@
@@ -139,7 +139,7 @@ index 619fd7d6..becaac81 100644
  #include <ctype.h>
  
 diff --git a/tests/tst_qmailmessageset/tst_qmailmessageset.cpp b/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
-index 7fc7083d..168fb891 100644
+index 01d10c52..331207c9 100644
 --- a/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
 +++ b/tests/tst_qmailmessageset/tst_qmailmessageset.cpp
 @@ -35,7 +35,7 @@
@@ -152,7 +152,7 @@ index 7fc7083d..168fb891 100644
  
  /*
 diff --git a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
-index 338d7ea6..e206479f 100644
+index 0a0d2ceb..9831f71a 100644
 --- a/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
 +++ b/tests/tst_qmailserviceaction/tst_qmailserviceaction.cpp
 @@ -36,7 +36,7 @@
@@ -165,7 +165,7 @@ index 338d7ea6..e206479f 100644
  
  
 diff --git a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
-index d6517662..e41e6e33 100644
+index 6f690e83..d46fcae2 100644
 --- a/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 +++ b/tests/tst_qmailstorageaction/tst_qmailstorageaction.cpp
 @@ -34,7 +34,7 @@
@@ -178,7 +178,7 @@ index d6517662..e41e6e33 100644
  #include <qmaildisconnected.h>
  #include <qmailnamespace.h>
 diff --git a/tests/tst_qmailstore/tst_qmailstore.cpp b/tests/tst_qmailstore/tst_qmailstore.cpp
-index 40fd3932..72ff657d 100644
+index deec061a..1d0c80d9 100644
 --- a/tests/tst_qmailstore/tst_qmailstore.cpp
 +++ b/tests/tst_qmailstore/tst_qmailstore.cpp
 @@ -38,7 +38,7 @@
@@ -191,7 +191,7 @@ index 40fd3932..72ff657d 100644
  //TESTED_CLASS=QMailStore
  //TESTED_FILES=src/libraries/qtopiamail/qmailstore.cpp
 diff --git a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
-index e881df8a..9af662de 100644
+index 6648d2e5..e603d9a4 100644
 --- a/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
 +++ b/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
 @@ -38,7 +38,7 @@
@@ -204,7 +204,7 @@ index e881df8a..9af662de 100644
  class tst_QMailStoreKeys : public QObject
  {
 diff --git a/tests/tst_qprivateimplementation/tst_qprivateimplementation.cpp b/tests/tst_qprivateimplementation/tst_qprivateimplementation.cpp
-index 4a96d78f..abb3d23f 100644
+index 5d48cd22..54b8db36 100644
 --- a/tests/tst_qprivateimplementation/tst_qprivateimplementation.cpp
 +++ b/tests/tst_qprivateimplementation/tst_qprivateimplementation.cpp
 @@ -33,7 +33,7 @@


### PR DESCRIPTION
Adjust the patch on list creators since parts of
servicehandler.cpp have been reformatted.

Get the caching strategy in SSO credential fetching.

@pvuorela , to be used with https://codereview.qt-project.org/c/qt-labs/messagingframework/+/675111 when later on merged upstream after discussions (will adjust the submodule accordingly).