### PR TITLE
[messagingframework] Fix initializing QMailAccount::folderSyncPolicy. JB#63886

### DIFF
--- a/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -9,13 +9,13 @@ when downloading messages from different folders.
 Also captures the sync policy as part of the QMailAccount structure.
 ---
  src/libraries/qmfclient/libaccounts_p.cpp     | 41 +++++++++++++++++
- src/libraries/qmfclient/qmailaccount.cpp      | 11 +++++
+ src/libraries/qmfclient/qmailaccount.cpp      | 12 +++++
  src/libraries/qmfclient/qmailaccount.h        | 10 +++++
  .../messageservices/imap/imapservice.cpp      |  7 ++-
  .../messageservices/imap/imapstrategy.cpp     | 45 +++++++++++++++++--
  .../messageservices/imap/imapstrategy.h       |  7 +--
  .../messageservices/pop/popservice.cpp        |  7 +++
- 7 files changed, 120 insertions(+), 8 deletions(-)
+ 7 files changed, 121 insertions(+), 8 deletions(-)
 
 diff --git a/src/libraries/qmfclient/libaccounts_p.cpp b/src/libraries/qmfclient/libaccounts_p.cpp
 index c6aa4b82..5d3f42d6 100644
@@ -91,10 +91,18 @@ index c6aa4b82..5d3f42d6 100644
          sharedAccount->selectService(service);
          sharedAccount->setValue(QLatin1String("type"), static_cast<int>(account->messageType()));
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index 52324bb5..bb2b115a 100644
+index 52324bb5..e791d896 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
-@@ -89,6 +89,7 @@ public:
+@@ -70,6 +70,7 @@ public:
+         , _messageType(QMailMessage::None)
+         , _status(0)
+         , _customFieldsModified(false)
++        , _folderSyncPolicy(QMailAccount::SyncInboxOnly)
+     {
+     }
+ 
+@@ -89,6 +90,7 @@ public:
      QStringList _sinks;
      QMap<QMailFolder::StandardFolder, QMailFolderId> _standardFolders;
      QString _iconPath;
@@ -102,7 +110,7 @@ index 52324bb5..bb2b115a 100644
  
      QMap<QString, QString> _customFields;
      bool _customFieldsModified;
-@@ -763,3 +764,13 @@ void QMailAccount::addMessageSink(const QString &sink)
+@@ -763,3 +765,13 @@ void QMailAccount::addMessageSink(const QString &sink)
  {
      d->_sinks.append(sink);
  }

--- a/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
+++ b/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
@@ -13,10 +13,10 @@ setting.
  3 files changed, 73 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index bb2b115a..d1c568b3 100644
+index e791d896..6b996616 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
-@@ -774,3 +774,56 @@ void QMailAccount::setFolderSyncPolicy(QMailAccount::FolderSyncPolicy policy)
+@@ -775,3 +775,56 @@ void QMailAccount::setFolderSyncPolicy(QMailAccount::FolderSyncPolicy policy)
  {
      d->_folderSyncPolicy = policy;
  }

--- a/rpm/0010-Allow-a-service-provided-folder-to-be-set-as-the-sta.patch
+++ b/rpm/0010-Allow-a-service-provided-folder-to-be-set-as-the-sta.patch
@@ -9,10 +9,10 @@ Subject: [PATCH] Allow a service provided folder to be set as the standard
  1 file changed, 4 insertions(+), 8 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index d1c568b3..35c7bf1e 100644
+index 6b996616..3ba5a080 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
-@@ -604,15 +604,11 @@ QMailFolderId QMailAccount::standardFolder(QMailFolder::StandardFolder folder) c
+@@ -605,15 +605,11 @@ QMailFolderId QMailAccount::standardFolder(QMailFolder::StandardFolder folder) c
  */
  void QMailAccount::setStandardFolder(QMailFolder::StandardFolder folder, const QMailFolderId &folderId)
  {


### PR DESCRIPTION
Classic uninitialized member variable. Does get set when account is created via libaccount integration though.

Default value the same as libaccount_p.ccp has when no config.