### PR TITLE
[messagingframework] Sync upstream. JB#61278

### DIFF
--- a/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
+++ b/rpm/0008-Retrieve-message-lists-based-on-the-folder-sync-poli.patch
@@ -91,7 +91,7 @@ index c6aa4b82..5d3f42d6 100644
          sharedAccount->selectService(service);
          sharedAccount->setValue(QLatin1String("type"), static_cast<int>(account->messageType()));
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index 52324bb5..e791d896 100644
+index 52324bb5..ddfc5ad3 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
 @@ -70,6 +70,7 @@ public:
@@ -102,14 +102,14 @@ index 52324bb5..e791d896 100644
      {
      }
  
-@@ -89,6 +90,7 @@ public:
-     QStringList _sinks;
-     QMap<QMailFolder::StandardFolder, QMailFolderId> _standardFolders;
-     QString _iconPath;
-+    QMailAccount::FolderSyncPolicy _folderSyncPolicy;
+@@ -92,6 +93,7 @@ public:
  
      QMap<QString, QString> _customFields;
      bool _customFieldsModified;
++    QMailAccount::FolderSyncPolicy _folderSyncPolicy;
+ 
+     QString customField(const QString &name) const
+     {
 @@ -763,3 +765,13 @@ void QMailAccount::addMessageSink(const QString &sink)
  {
      d->_sinks.append(sink);

--- a/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
+++ b/rpm/0009-Apply-folder-policy-to-always-on-connection.patch
@@ -13,7 +13,7 @@ setting.
  3 files changed, 73 insertions(+), 1 deletion(-)
 
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index e791d896..6b996616 100644
+index ddfc5ad3..2b3fb891 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
 @@ -775,3 +775,56 @@ void QMailAccount::setFolderSyncPolicy(QMailAccount::FolderSyncPolicy policy)

--- a/rpm/0010-Allow-a-service-provided-folder-to-be-set-as-the-sta.patch
+++ b/rpm/0010-Allow-a-service-provided-folder-to-be-set-as-the-sta.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Allow a service provided folder to be set as the standard
  1 file changed, 4 insertions(+), 8 deletions(-)
 
 diff --git a/src/libraries/qmfclient/qmailaccount.cpp b/src/libraries/qmfclient/qmailaccount.cpp
-index 6b996616..3ba5a080 100644
+index 2b3fb891..86a08eb3 100644
 --- a/src/libraries/qmfclient/qmailaccount.cpp
 +++ b/src/libraries/qmfclient/qmailaccount.cpp
 @@ -605,15 +605,11 @@ QMailFolderId QMailAccount::standardFolder(QMailFolder::StandardFolder folder) c

--- a/rpm/0011-Adjust-for-Qt-5.6.patch
+++ b/rpm/0011-Adjust-for-Qt-5.6.patch
@@ -224,7 +224,7 @@ index a4545ce5..4ea9c5ac 100644
      friend class QMailMessageSetContainer;
      friend class QMailMessageSet;
 diff --git a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
-index c3167088..06c333fd 100644
+index ae50579b..2591bbd5 100644
 --- a/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
 +++ b/src/plugins/contentmanagers/qmfstoragemanager/qmfstoragemanager.cpp
 @@ -43,7 +43,6 @@

--- a/rpm/0012-Adjust-for-Qt-5.14.patch
+++ b/rpm/0012-Adjust-for-Qt-5.14.patch
@@ -75,7 +75,7 @@ index 31f8541c..7be74e21 100644
  
      return QMailMessageKey(uids, CopyServerUid, QMailKey::comparator(cmp));
 diff --git a/src/libraries/qmfclient/qmailmessagelistmodel.cpp b/src/libraries/qmfclient/qmailmessagelistmodel.cpp
-index d8f69875..2b1dd8b1 100644
+index 518b983b..e059aee9 100644
 --- a/src/libraries/qmfclient/qmailmessagelistmodel.cpp
 +++ b/src/libraries/qmfclient/qmailmessagelistmodel.cpp
 @@ -402,9 +402,7 @@ bool QMailMessageListModelPrivate::updateMessages(const QMailMessageIdList &ids)
@@ -90,10 +90,10 @@ index d8f69875..2b1dd8b1 100644
      QMap<QMailMessageId, int> newPositions;
  
 diff --git a/src/libraries/qmfclient/qmailmessageset.cpp b/src/libraries/qmfclient/qmailmessageset.cpp
-index 72242950..12b57a4d 100644
+index 0085953d..3fb6bfec 100644
 --- a/src/libraries/qmfclient/qmailmessageset.cpp
 +++ b/src/libraries/qmfclient/qmailmessageset.cpp
-@@ -976,7 +976,7 @@ void QMailFilterMessageSet::messagesAdded(const QMailMessageIdList &ids)
+@@ -985,7 +985,7 @@ void QMailFilterMessageSet::messagesAdded(const QMailMessageIdList &ids)
          QMailMessageIdList matchingIds = QMailStore::instance()->queryMessages(key & idFilter);
          if (!matchingIds.isEmpty()) {
              // Our filtered message set has changed
@@ -102,7 +102,7 @@ index 72242950..12b57a4d 100644
              update(this);
          }
      }
-@@ -989,7 +989,7 @@ void QMailFilterMessageSet::messagesRemoved(const QMailMessageIdList &ids)
+@@ -998,7 +998,7 @@ void QMailFilterMessageSet::messagesRemoved(const QMailMessageIdList &ids)
  
      QSet<QMailMessageId>& _messageIds = d->_messageIds;
      if (!_messageIds.isEmpty()) {
@@ -111,7 +111,7 @@ index 72242950..12b57a4d 100644
  
          // See if any of these messages are in our set
          removedIds.intersect(_messageIds);
-@@ -1008,12 +1008,11 @@ void QMailFilterMessageSet::messagesUpdated(const QMailMessageIdList &ids)
+@@ -1017,12 +1017,11 @@ void QMailFilterMessageSet::messagesUpdated(const QMailMessageIdList &ids)
      QMailMessageKey key(messageKey());
      if (!key.isNonMatching()) {
          QSet<QMailMessageId>& _messageIds = d->_messageIds;
@@ -126,7 +126,7 @@ index 72242950..12b57a4d 100644
  
          QSet<QMailMessageId> presentIds = updatedIds;
          QSet<QMailMessageId> absentIds = updatedIds;
-@@ -1062,8 +1061,7 @@ void QMailFilterMessageSet::resyncState()
+@@ -1071,8 +1070,7 @@ void QMailFilterMessageSet::resyncState()
      Q_D(QMailFilterMessageSet);
  
      if (d->_minimized) {
@@ -136,16 +136,16 @@ index 72242950..12b57a4d 100644
      } else {
          d->_messageIds.clear();
      }
-@@ -1085,8 +1083,7 @@ void QMailFilterMessageSet::reset()
-     if (d->_minimized) {
-         disconnect(model(), SIGNAL(folderContentsModified(QMailFolderIdList)), this, SLOT(folderContentsModified(QMailFolderIdList)));
+@@ -1095,8 +1093,7 @@ void QMailFilterMessageSet::reset()
+         disconnect(model(), &QMailMessageSetModel::folderContentsModified,
+                    this, &QMailFilterMessageSet::folderContentsModified);
  
 -        const QMailMessageIdList ids = QMailStore::instance()->queryMessages(messageKey());
 -        d->_messageIds = QSet<QMailMessageId>(ids.constBegin(), ids.constEnd());
 +        d->_messageIds = QSet<QMailMessageId>::fromList(QMailStore::instance()->queryMessages(messageKey()));
  
-         connect(model(), SIGNAL(messagesAdded(QMailMessageIdList)), this, SLOT(messagesAdded(QMailMessageIdList)));
-         connect(model(), SIGNAL(messagesRemoved(QMailMessageIdList)), this, SLOT(messagesRemoved(QMailMessageIdList)));
+         connect(model(), &QMailMessageSetModel::messagesAdded,
+                 this, &QMailFilterMessageSet::messagesAdded);
 diff --git a/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp b/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp
 index 452f7c55..4eb5afa3 100644
 --- a/src/libraries/qmfclient/qmailmessagethreadedmodel.cpp


### PR DESCRIPTION
Fixed a minor glitch in earlier changes where foldersyncpolicy init order was wrong.