### PR TITLE
[messagingframework] Register a dummy notification service for sailjail. JB#63998

### DIFF
--- a/rpm/0016-Register-a-dummy-service-for-storage-notifications.patch
+++ b/rpm/0016-Register-a-dummy-service-for-storage-notifications.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pekka Vuorela <pekka.vuorela@jolla.com>
+Date: Wed, 25 Mar 2026 11:42:22 +0200
+Subject: [PATCH] Register a dummy service for storage notifications
+
+Apparently it's not possible to define sailjail/xdg-dbus-proxy rule
+for allowing to listen specific signals sent by anyone.
+
+As band-aid to make it possible, defining here a dummy service which
+can then be explicitly allowed.
+---
+ src/libraries/qmfclient/qmailstorenotifier_p.cpp | 13 +++++++++++++
+ src/libraries/qmfclient/qmailstorenotifier_p.h   |  1 +
+ 2 files changed, 14 insertions(+)
+
+diff --git a/src/libraries/qmfclient/qmailstorenotifier_p.cpp b/src/libraries/qmfclient/qmailstorenotifier_p.cpp
+index 87508cec..608ff4c0 100644
+--- a/src/libraries/qmfclient/qmailstorenotifier_p.cpp
++++ b/src/libraries/qmfclient/qmailstorenotifier_p.cpp
+@@ -40,6 +40,7 @@
+ #include <qmailipc.h>
+ 
+ #include <QCoreApplication>
++#include <QUuid>
+ 
+ namespace {
+ 
+@@ -134,6 +135,15 @@ QMailStoreNotifier::QMailStoreNotifier(QObject* parent)
+         qCritical() << "Failed to register to D-Bus, notifications to other clients will not work.";
+     }
+ 
++    const QString uuid = QUuid::createUuid().toString();
++    serviceName = QString::fromLatin1("org.qt.mailstore.client")
++            + uuid.mid(1, uuid.length() - 2).replace('-', QString());
++
++    if (!QDBusConnection::sessionBus().registerService(serviceName)) {
++        qCritical() << "Failed to register Qmf client notifier to D-Bus service" << serviceName;
++        serviceName.clear();
++    }
++
+     QMailIpc::init();
+     reconnectIpc();
+ 
+@@ -156,6 +166,9 @@ QMailStoreNotifier::QMailStoreNotifier(QObject* parent)
+ 
+ QMailStoreNotifier::~QMailStoreNotifier()
+ {
++    if (!serviceName.isEmpty()) {
++        QDBusConnection::sessionBus().unregisterService(serviceName);
++    }
+     QDBusConnection::sessionBus().unregisterObject(QString::fromLatin1("/mailstore/client"));
+ }
+ 
+diff --git a/src/libraries/qmfclient/qmailstorenotifier_p.h b/src/libraries/qmfclient/qmailstorenotifier_p.h
+index cec4002b..69d3c16a 100644
+--- a/src/libraries/qmfclient/qmailstorenotifier_p.h
++++ b/src/libraries/qmfclient/qmailstorenotifier_p.h
+@@ -155,6 +155,7 @@ private:
+     QSet<QMailAccountId> transmissionInProgressIds;
+ 
+     MailstoreAdaptor *ipcAdaptor;
++    QString serviceName;
+ };
+ 
+ #endif

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -47,7 +47,7 @@ Patch0012: 0012-Adjust-for-Qt-5.14.patch
 Patch0013: 0013-Revert-Set-PLUGIN_CLASS_NAME-in-plugin-.pro-files.patch
 Patch0014: 0014-Revert-Bump-version-to-6.0.0-since-we-build-against-.patch
 Patch0015: 0015-Fallback-to-sso-credential-plugin.patch
-
+Patch0016: 0016-Register-a-dummy-service-for-storage-notifications.patch
 
 %description
 The Qt Messaging Framework, QMF, consists of a C++ library and daemon server


### PR DESCRIPTION
Depends on: https://github.com/sailfishos/sailjail-permissions/pull/152

Would be nice if this wasn't needed at all, thus not yet pushing upstream, but seems like xdg-dbus-proxy would need changes to work properly with these signals without registration. Sigh. 

cc @dcaliste 